### PR TITLE
Large content modal enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
+this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 #### [Unreleased]
+
+## [2.0.0-beta] - 2017-12--05
+
+### Fixed
+
+* `<Alert/>` components now render visible by default. The `withActive` HOC has been
+  updated to accept a `defaultActive` configuration to enable this.
+
+### Changed
+
+* The `<State/>` component has been renamed to `<Active/>` for better semantics.
+* The `withState` HOC is removed. The `<State>` component supports yielding active
+  state and handlers through function as a child.
 
 ## [2.0.0-alpha.4] - 2017-11-20
 
 ### Fixed
-- Display names for `Alert`, `Modal` and `ModalTitle` components fixed.
-- Correctly handle passing active props directly to `withState`.
-- Remove event listeners in `state-container` components on `componentWillUnmount`.
+
+* Display names for `Alert`, `Modal` and `ModalTitle` components fixed.
+* Correctly handle passing active props directly to `withState`.
+* Remove event listeners in `state-container` components on `componentWillUnmount`.

--- a/lib/Modal/Modal.jsx
+++ b/lib/Modal/Modal.jsx
@@ -15,22 +15,23 @@ type Props = {
   ariaTitle?: string,
   children?: Node,
   deactivate?: Function,
-  size?: 'small' | 'large',
+  size?: 'sm' | 'lg',
   visible?: boolean
 }
 
-/**
- * TODO:
- * - Close button auto-wiring of aria-label=close && deactivate
- * - Close on escape** - All toggle items!
- * - Auto focus on open
- * - Animated open/close
- * - Docs on passing flex align-items-center/start to header for close icon alignment
- * - Add close button when `ariaTitle is used
- *
- * ## Notes:
- * See MDN [Using the dialog role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role)
- */
+// /**
+//  * TODO:
+//  * - Close button auto-wiring of aria-label=close && deactivate
+//  * - Close on escape** - All toggle items!
+//  * - Auto focus on open
+//  * - Animated open/close
+//  * - Docs on passing flex align-items-center/start to header for close icon alignment
+//  * - Add close button when `ariaTitle is used
+//  *
+//  * ## Notes:
+//  * See MDN [Using the dialog role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role)
+//  */
+
 class Modal extends Component<Props> {
   static Header = elementFactory({ classes: 'modal-header', name: 'ModalHeader' })
   static Body = elementFactory({ classes: 'modal-body', name: 'ModalBody' })
@@ -49,6 +50,15 @@ class Modal extends Component<Props> {
    * used to wire together title aria attributes
    */
   guid = nanoid()
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.active && nextProps.active) {
+      document.body.classList.add('modal-open')
+    }
+    if (this.props.active && !nextProps.active) {
+      document.body.classList.remove('modal-open')
+    }
+  }
 
   // Render
   // ---------------------------------------------------------------------------
@@ -69,13 +79,7 @@ class Modal extends Component<Props> {
         tabIndex="-1"
       >
         {/* See SCSS file for explanation on backdrop markdown order/position */}
-        <div
-          aria-hidden={active ? 'false' : 'true'}
-          className={classNames('modal-backdrop', 'fade', { show: visible })}
-          onClick={deactivate}
-          onKeyPress={deactivate}
-          role="presentation"
-        />
+
         <div
           className={classNames('modal-dialog', { [`modal-${size}`]: size })}
           role="document"
@@ -91,6 +95,13 @@ class Modal extends Component<Props> {
             {children}
           </div>
         </div>
+        <div
+          aria-hidden={active ? 'false' : 'true'}
+          className={classNames('modal-backdrop', 'fade', { show: visible })}
+          onClick={deactivate}
+          onKeyPress={deactivate}
+          role="presentation"
+        />
       </div>
     )
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "componentry",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-beta",
   "description": "Radical React Components",
   "main": "dist/componentry.js",
   "module": "es/index.js",
@@ -35,14 +35,7 @@
     "styles:minify": "cleancss -o dist/componentry.min.css dist/componentry.css",
     "styles:copy": "cp -r styles/* dist"
   },
-  "keywords": [
-    "react",
-    "components",
-    "ui",
-    "508",
-    "accessible",
-    "bootstrap"
-  ],
+  "keywords": ["react", "components", "ui", "508", "accessible", "bootstrap"],
   "author": "Dan Hedgecock <hedgecock.d@gmail.com>",
   "license": "MIT",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "componentry",
-  "version": "2.0.0-beta",
+  "version": "2.0.1-beta",
   "description": "Radical React Components",
   "main": "dist/componentry.js",
   "module": "es/index.js",

--- a/src/components/ComponentsScreen/ModalsScreen/ModalsScreen.jsx
+++ b/src/components/ComponentsScreen/ModalsScreen/ModalsScreen.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 
-import { Active, Button, Modal } from 'componentry-lib'
+import { Active, Button, Modal, Drawer } from 'componentry-lib'
 
 type ComponentState = {
   controlledModal: boolean
@@ -44,7 +44,85 @@ export default class Modals extends Component<{}, ComponentState> {
                       </svg>
                     </Active.Trigger>
                   </Modal.Header>
-                  <Modal.Body>This is a modal</Modal.Body>
+                  <Modal.Body>
+                    This is a modal
+                    <Drawer>
+                      <Drawer.Trigger link className="my-2">
+                        <svg role="img" className="icon chevron font">
+                          <use href="#chevron" />
+                        </svg>
+                        Reveal more content
+                      </Drawer.Trigger>
+                      <Drawer.Content>
+                        Esse nulla excepteur amet minim et sed dolor laborum laboris
+                        id laborum ad non laboris sunt in sed excepteur ut dolor in
+                        eu proident consequat in proident proident incididunt sunt
+                        sint ea in deserunt aliqua aute velit magna ut culpa nulla
+                        ut sint in dolore consequat ut velit sit non est incididunt
+                        amet ut amet amet magna consequat quis sed veniam ex cillum
+                        est commodo nostrud velit ut ut commodo laborum exercitation
+                        in eu qui irure aliquip nulla dolor eu magna nisi irure sint
+                        voluptate id incididunt reprehenderit occaecat duis nisi
+                        minim commodo ea aliquip tempor irure velit eu laborum
+                        veniam cupidatat mollit id esse laborum incididunt consequat
+                        quis non non quis ut mollit pariatur nisi ad laborum velit
+                        aliqua culpa officia dolore non nisi mollit non ea cupidatat
+                        do sed nostrud aute incididunt tempor aliqua eiusmod mollit
+                        nulla in in aute magna dolor nulla ad reprehenderit ut minim
+                        non labore velit enim duis nulla minim voluptate laboris ut
+                        laborum anim incididunt anim sint laboris non consequat
+                        culpa esse dolor sed sit ea sit occaecat consequat ut
+                        voluptate in dolore ad ea irure veniam in dolore dolor
+                        consequat qui pariatur sunt qui do nisi proident dolore est
+                        sit laboris adipisicing cillum veniam et reprehenderit do
+                        laboris magna id.This is a modalEsse nulla excepteur amet
+                        minim et sed dolor laborum laboris id laborum ad non laboris
+                        sunt in sed excepteur ut dolor in eu proident consequat in
+                        proident proident incididunt sunt sint ea in deserunt aliqua
+                        aute velit magna ut culpa nulla ut sint in dolore consequat
+                        ut velit sit non est incididunt amet ut amet amet magna
+                        consequat quis sed veniam ex cillum est commodo nostrud
+                        velit ut ut commodo laborum exercitation in eu qui irure
+                        aliquip nulla dolor eu magna nisi irure sint voluptate id
+                        incididunt reprehenderit occaecat duis nisi minim commodo ea
+                        aliquip tempor irure velit eu laborum veniam cupidatat
+                        mollit id esse laborum incididunt consequat quis non non
+                        quis ut mollit pariatur nisi ad laborum velit aliqua culpa
+                        officia dolore non nisi mollit non ea cupidatat do sed
+                        nostrud aute incididunt tempor aliqua eiusmod mollit nulla
+                        in in aute magna dolor nulla ad reprehenderit ut minim non
+                        labore velit enim duis nulla minim voluptate laboris ut
+                        laborum anim incididunt anim sint laboris non consequat
+                        culpa esse dolor sed sit ea sit occaecat consequat ut
+                        voluptate in dolore ad ea irure veniam in dolore dolor
+                        consequat qui pariatur sunt qui do nisi proident dolore est
+                        sit laboris adipisicing cillum veniam et reprehenderit do
+                        laboris magna id.This is a modalEsse nulla excepteur amet
+                        minim et sed dolor laborum laboris id laborum ad non laboris
+                        sunt in sed excepteur ut dolor in eu proident consequat in
+                        proident proident incididunt sunt sint ea in deserunt aliqua
+                        aute velit magna ut culpa nulla ut sint in dolore consequat
+                        ut velit sit non est incididunt amet ut amet amet magna
+                        consequat quis sed veniam ex cillum est commodo nostrud
+                        velit ut ut commodo laborum exercitation in eu qui irure
+                        aliquip nulla dolor eu magna nisi irure sint voluptate id
+                        incididunt reprehenderit occaecat duis nisi minim commodo ea
+                        aliquip tempor irure velit eu laborum veniam cupidatat
+                        mollit id esse laborum incididunt consequat quis non non
+                        quis ut mollit pariatur nisi ad laborum velit aliqua culpa
+                        officia dolore non nisi mollit non ea cupidatat do sed
+                        nostrud aute incididunt tempor aliqua eiusmod mollit nulla
+                        in in aute magna dolor nulla ad reprehenderit ut minim non
+                        labore velit enim duis nulla minim voluptate laboris ut
+                        laborum anim incididunt anim sint laboris non consequat
+                        culpa esse dolor sed sit ea sit occaecat consequat ut
+                        voluptate in dolore ad ea irure veniam in dolore dolor
+                        consequat qui pariatur sunt qui do nisi proident dolore est
+                        sit laboris adipisicing cillum veniam et reprehenderit do
+                        laboris magna id.
+                      </Drawer.Content>
+                    </Drawer>
+                  </Modal.Body>
                   <Modal.Footer>
                     <Active.Trigger color="dark" outline>
                       Close

--- a/styles/bootstrap/_modal.scss
+++ b/styles/bootstrap/_modal.scss
@@ -74,7 +74,6 @@
   left: 0;
   z-index: $zindex-modal-backdrop;
   background-color: $modal-backdrop-bg;
-  pointer-events: none;
   overflow: hidden;
 
   // Fade for backdrop

--- a/styles/bootstrap/_modal.scss
+++ b/styles/bootstrap/_modal.scss
@@ -4,9 +4,10 @@
 // .modal-content   - actual modal w/ bg and corners and stuff
 
 
-// Kill the scroll on the body
+// This only works when .modal-open is attached to <body>
 .modal-open {
   overflow: hidden;
+  height: 100vh;
 }
 
 // Container that the modal scrolls within
@@ -18,7 +19,7 @@
   left: 0;
   z-index: $zindex-modal;
   display: none;
-  overflow: hidden;
+  overflow: scroll;
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951.
   outline: 0;
@@ -45,6 +46,7 @@
   margin: $modal-dialog-margin;
   // allow clicks to pass through for custom click handling to close modal
   pointer-events: none;
+  z-index: calc(#{$zindex-modal-backdrop} + 1);
 }
 
 // Actual modal
@@ -72,6 +74,8 @@
   left: 0;
   z-index: $zindex-modal-backdrop;
   background-color: $modal-backdrop-bg;
+  pointer-events: none;
+  overflow: hidden;
 
   // Fade for backdrop
   &.fade { opacity: 0; }


### PR DESCRIPTION
* Allow for modals to scroll off the page.  
* Toggle `modal-open` on <body>

The way that `modal-open` is toggled on <body> is obviously not the React way, but it seemed like a good way to do it so that the Componentry consuming app doesn't have to take another step like adding a REF or something to it's index.