### PR TITLE
fix(components): ensure context and props classnames are passed through

### DIFF
--- a/lib/Nav/NavItem.jsx
+++ b/lib/Nav/NavItem.jsx
@@ -6,7 +6,7 @@ import elementFactory from '../component-factories/element-factory'
 export default elementFactory({
   name: 'NavItem',
   computedClassName: (ctxClassName, propsClassName, { href, to }) =>
-    classNames('nav-item', {
+    classNames('nav-item', ctxClassName, propsClassName, {
       'nav-link': href || to,
     }),
   computedTag: props => (props.onClick ? Button : 'a'),

--- a/lib/Nav/NavItem.spec.jsx
+++ b/lib/Nav/NavItem.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import NavItem from './NavItem'
+import elementTests from '../utils-test/element-tests'
+
+describe('<NavItem />', () => {
+  // Basic library element test suite
+  elementTests(NavItem)
+
+  test('should render an anchor with class nav-item by default', () => {
+    const wrapper = shallow(<NavItem />)
+    expect(wrapper.find('a').length).toEqual(1)
+    expect(wrapper.find('.nav-item').length).toEqual(1)
+  })
+
+  test('should render a Button when passed an onClick', () => {
+    const handleClick = jest.fn()
+    const wrapper = shallow(<NavItem onClick={handleClick} />)
+
+    expect(wrapper.find('Button').length).toEqual(1)
+  })
+})


### PR DESCRIPTION
ISSUES CLOSED: #4

<!--
  👋 Hello friend, thank you for contributing to Componentry, you are AWESOME 😍
  Please use this helpful template for filing Pull Requests. (the CONTRIBUTING
  guide contains motivation on these detials).
-->

<!-- PR Summary -->

* 🐛 Fixes classname props not being passed through to the `<NavItem />` component.
* ✅ Added tests for NavItem component

## Requirements

* [x] PR is targeted against `develop` branch
* [x] Commit messages created with `commitizen` <!-- hint: npm run commit -->
* [x] Tests added for changes
* [x] All tests are _definitely_ passing <!-- hint: npm test -->
