### PR TITLE
refactor(components): wrap poppers in content container 🔨

### DIFF
--- a/lib/Popover/Popover.js
+++ b/lib/Popover/Popover.js
@@ -9,8 +9,7 @@ const Content = activeContent({
   componentArias: { id: true, role: 'tooltip', hidden: true },
   element: 'popover',
   name: 'PopoverContent',
-  tip: true,
-  widthValidation: true,
+  popper: true,
 })
 const withActiveContent = withActive()(Content)
 

--- a/lib/Popover/__snapshots__/Popover.spec.jsx.snap
+++ b/lib/Popover/__snapshots__/Popover.spec.jsx.snap
@@ -18,20 +18,24 @@ exports[`renders correctly 1`] = `
     Trigger
   </button>
   <div
-    aria-hidden="true"
-    className="popover-content"
-    data-test="popover-content"
-    id="guid"
-    role="tooltip"
+    className="popover-content-container"
   >
     <div
-      className="tip-container"
+      aria-hidden="true"
+      className="popover-content"
+      data-test="popover-content"
+      id="guid"
+      role="tooltip"
     >
       <div
-        className="tip"
-      />
+        className="tip-container"
+      >
+        <div
+          className="tip"
+        />
+      </div>
+      Content
     </div>
-    Content
   </div>
 </div>
 `;

--- a/lib/Popover/popover.scss
+++ b/lib/Popover/popover.scss
@@ -19,6 +19,33 @@
   position: relative;
 }
 
+// Content container overrides the width constraints for parent element
+.popover-content-container {
+  width: $popover-max-width;
+  position: absolute;
+  display: inline-flex;
+
+  &.top {
+    bottom: 100%;
+    justify-content: center;
+  }
+
+  &.right {
+    left: 100%;
+    align-items: center;
+  }
+
+  &.bottom {
+    top: 100%;
+    justify-content: center;
+  }
+
+  &.left {
+    right: 100%;
+    align-items: center;
+  }
+}
+
 // Content Element - The content element should be used to wrap a body/header element
 .popover-content {
   @include border-radius($border-radius-lg);
@@ -75,7 +102,6 @@
 
   &.bottom {
     margin-top: $popover-arrow-width;
-    top: 100%;
 
     .tip-container {
       bottom: 100%;
@@ -87,6 +113,8 @@
   }
 
   &.top {
+    // Top requires bumping bottom 100% again to compensate for container not having
+    // any height
     bottom: 100%;
     margin-bottom: $popover-arrow-width;
 
@@ -106,7 +134,6 @@
   }
 
   &.right {
-    left: 100%;
     margin-left: $popover-arrow-width;
 
     .tip-container {
@@ -120,7 +147,8 @@
 
   &.left {
     margin-right: $popover-arrow-width;
-    right: 100%;
+    // left requires right 0 to compensate for absolute positioning
+    right: 0;
 
     .tip-container {
       right: -$popover-arrow-width * 2;

--- a/lib/Tooltip/Tooltip.js
+++ b/lib/Tooltip/Tooltip.js
@@ -8,8 +8,7 @@ const Content = activeContent({
   componentArias: { id: true, role: 'tooltip', hidden: true },
   element: 'tooltip',
   name: 'TooltipContent',
-  tip: true,
-  widthValidation: true,
+  popper: true,
 })
 const withActiveContent = withActive()(Content)
 

--- a/lib/Tooltip/__snapshots__/Tooltip.spec.jsx.snap
+++ b/lib/Tooltip/__snapshots__/Tooltip.spec.jsx.snap
@@ -18,20 +18,24 @@ exports[`renders correctly 1`] = `
     Trigger
   </button>
   <div
-    aria-hidden="true"
-    className="tooltip-content"
-    data-test="tooltip-content"
-    id="guid"
-    role="tooltip"
+    className="tooltip-content-container"
   >
     <div
-      className="tip-container"
+      aria-hidden="true"
+      className="tooltip-content"
+      data-test="tooltip-content"
+      id="guid"
+      role="tooltip"
     >
       <div
-        className="tip"
-      />
+        className="tip-container"
+      >
+        <div
+          className="tip"
+        />
+      </div>
+      Content
     </div>
-    Content
   </div>
 </div>
 `;

--- a/lib/Tooltip/tooltip.scss
+++ b/lib/Tooltip/tooltip.scss
@@ -16,6 +16,12 @@
   position: relative;
 }
 
+// Content container overrides the width constraints for parent element
+.tooltip-content-container {
+  width: $tooltip-max-width;
+  position: absolute;
+}
+
 // Content
 .tooltip-content {
   @include border-radius($border-radius); // Adds border radius
@@ -23,13 +29,12 @@
   background-color: $tooltip-bg;
   color: $tooltip-color;
   font-size: $font-size-sm;
-  left: 0;
   margin-top: $tooltip-arrow-width;
   max-width: $tooltip-max-width;
   padding: $tooltip-padding-y $tooltip-padding-x;
-  position: absolute;
+  position: relative;
+  display: inline-block;
   text-align: left;
-  top: 100%;
   word-wrap: break-word; // Allow breaking very long words so they don't overflow the popover's bounds
   z-index: $zindex-tooltip;
 

--- a/lib/component-factories/active-content.jsx
+++ b/lib/component-factories/active-content.jsx
@@ -1,12 +1,11 @@
 // @flow
-import React, { Component, createElement } from 'react'
+import React, { createElement } from 'react'
 import type { Node, ComponentType } from 'react'
 import { object, shape } from 'prop-types'
 import classNames from 'classnames'
 
 import arias from '../utils/arias'
 import type { ComponentArias } from '../utils/arias'
-import { getTextWidth } from '../utils/dom'
 
 type Options = {
   classes?: string,
@@ -16,26 +15,32 @@ type Options = {
   element?: string,
   /** The display name for the component, specified for better debugging */
   name: string,
-  /** Flag to include the markup for a content tip element */
-  tip?: boolean,
-  /** When true validate element width does not overflow page on activate */
-  widthValidation?: boolean,
+  /** Popper elements are tooltips and popovers, they include extra markup */
+  popper?: boolean,
 }
 
 // TODO: is this fixable?
 /* eslint-disable react/no-unused-prop-types */
+/* eslint-disable react/require-default-props */
 type Props = {
   // Component props
   as?: ComponentType<any> | string,
   children?: Node,
   className?: string,
   activeId?: string,
+  // Position
+  top?: boolean,
+  right?: boolean,
+  bottom?: boolean,
+  left?: boolean,
   // Active boolean + change handlers from withActive HOC
   activate: Function,
   active: boolean,
   deactivate: Function,
   guid: string,
 }
+
+type Context = { [string]: { [string]: any } }
 
 /**
  * Factory returns custom `<Content />` components defined by the options.
@@ -45,114 +50,89 @@ export default ({
   componentArias,
   element = '',
   name,
-  tip = false,
-  widthValidation = false,
-}: Options = {}) =>
-  class Content extends Component<Props> {
-    static displayName = name
-    static contextTypes = { THEME: shape({ [name]: object }) }
+  popper = false,
+}: Options = {}) => {
+  const Content = (props: Props, { THEME = {} }: Context) => {
+    const componentCtx = THEME[name] || {}
+    const {
+      active,
+      // $FlowFixMe
+      as,
+      children,
+      guid,
+      activeId = '',
+      // Position
+      top,
+      right,
+      bottom,
+      left,
+      // YOU SHALL NOT PASS 🙅
+      className,
+      activate,
+      deactivate,
+      ...rest
+    }: Props = { ...componentCtx, ...props }
 
-    /**
-     * Internal cache for width of tooltip content. Set after calculating content
-     * width and reused on subsequent renders if content text has not changed.
-     */
-    contentWidth: number = 0
-    /**
-     * Internal cache for tooltip content. Used to check if the content has changed
-     * between showings of tooltip.
-     */
-    content: string = ''
+    // Create component content (return optionally wraps content in a width busting
+    // container)
+    const ComponentContent = createElement(
+      as || 'div',
+      {
+        'data-test': element ? `${element}-content` : undefined,
+        ...arias({
+          guid,
+          active,
+          ...componentArias,
+          // Mutli-active elems have different arias to handle multiple show/hide
+          // elements. The passed id is used for trigger and content components,
+          // these arias will override the standard componentArias
+          ...(activeId
+            ? {
+                active: activeId === active,
+                id: `${activeId}-content`,
+                labelledby: `${activeId}-trigger`,
+                hidden: true,
+              }
+            : {}),
+        }),
+        className:
+          classNames(classes, componentCtx.className, props.className, {
+            [`${element}-content`]: element,
+            top,
+            right,
+            bottom,
+            left,
+          }) || undefined,
+        ...rest,
+      },
+      popper && (
+        <div className="tip-container">
+          <div className="tip" />
+        </div>
+      ),
+      children,
+    )
 
-    // Hooks
-    // ---------------------------------------------------------------------------
-    componentDidMount() {
-      if (widthValidation && this.props.active) this.validateWidth()
-    }
-
-    componentDidUpdate() {
-      if (widthValidation && this.props.active) this.validateWidth()
-    }
-
-    // Methods
-    // ---------------------------------------------------------------------------
-    /** Check width and update the styles for display */
-    validateWidth() {
-      // Position absolute tooltip & popover is constrained by the parent width.
-      // Set tooltip width to content width to overflow parent bounds
-      const contentElement = document.getElementById(this.props.guid)
-      if (!contentElement) return // Bail out just in case nothing is found
-
-      const content = contentElement.innerText || ''
-      this.content = content
-
-      if (content === this.content && this.contentWidth) {
-        // If width has already been calculated and content has not changed, use
-        // cached width for performance
-        contentElement.style.width = `${this.contentWidth}px`
-      } else {
-        // Get all styles of content element, set width and cache
-        const styles = window.getComputedStyle(contentElement)
-        // Get padding, font size and font family of content
-        const width =
-          getTextWidth(content, `${styles.fontSize} ${styles.fontFamily}`) +
-          parseFloat(styles.paddingLeft) +
-          parseFloat(styles.paddingRight) +
-          1
-
-        contentElement.style.width = `${width}px`
-        this.contentWidth = width
-      }
-    }
-
-    render() {
-      const THEME = this.context.THEME || {}
-      const componentCtx = THEME[name] || {}
-      const {
-        active,
-        // $FlowFixMe
-        as,
-        children,
-        guid,
-        activeId = '',
-        // YOU SHALL NOT PASS 🙅
-        className,
-        activate,
-        deactivate,
-        ...rest
-      }: Props = { ...componentCtx, ...this.props }
-
-      return createElement(
-        as || 'div',
-        {
-          'data-test': element ? `${element}-content` : undefined,
-          ...arias({
-            guid,
-            active,
-            ...componentArias,
-            // Mutli-active elems have different arias to handle multiple show/hide
-            // elements. The passed id is used for trigger and content components,
-            // these arias will override the standard componentArias
-            ...(activeId
-              ? {
-                  active: activeId === active,
-                  id: `${activeId}-content`,
-                  labelledby: `${activeId}-trigger`,
-                  hidden: true,
-                }
-              : {}),
-          }),
-          className:
-            classNames(classes, componentCtx.className, this.props.className, {
-              [`${element}-content`]: element,
-            }) || undefined,
-          ...rest,
-        },
-        tip && (
-          <div className="tip-container">
-            <div className="tip" />
-          </div>
-        ),
-        children,
-      )
-    }
+    // If the element is a popper, wrap it in a content container, this is used to
+    // bust width of parent element
+    return popper ? (
+      <div
+        className={classNames(`${element}-content-container`, {
+          top,
+          right,
+          bottom,
+          left,
+        })}
+      >
+        {ComponentContent}
+      </div>
+    ) : (
+      ComponentContent
+    )
   }
+
+  Content.displayName = name
+  Content.contextTypes = { THEME: shape({ [name]: object }) }
+
+  return Content
+}

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+
 /**
  * Find the closest DOM parent with the passed `className`. If a matching ancestor
  * is not found return `null`
@@ -26,15 +28,15 @@ export function closest(target, className) {
  * @param {String} font The css font descriptor that text is to be rendered with (e.g. "bold 14px verdana").
  * @return {string} The width of the text in a px string format, eg: `'467px'`
  */
-export function getTextWidth(text, font) {
-  // re-use canvas object for better performance
-  const canvas =
-    getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'))
-  const context = canvas.getContext('2d')
-  context.font = font
-  const metrics = context.measureText(text)
-  return metrics.width
-}
+// export function getTextWidth(text, font) {
+//   // re-use canvas object for better performance
+//   const canvas =
+//     getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'))
+//   const context = canvas.getContext('2d')
+//   context.font = font
+//   const metrics = context.measureText(text)
+//   return metrics.width
+// }
 
 // NOTE: The new Bootstrap focus box-shadow looks nice, so we're not suppressing it
 // any longer. If everything is after a few releases remove this.

--- a/src/components/ComponentsScreen/PopoversScreen/Popovers.md
+++ b/src/components/ComponentsScreen/PopoversScreen/Popovers.md
@@ -1,9 +1,48 @@
 <p className="lead">Popover component...</p>
 <Popover>
   <Popover.Trigger color="primary" outline>
-    Popover Trigger
+    Popover Top
   </Popover.Trigger>
-  <Popover.Content className="right">
+  <Popover.Content top>
+    <Popover.Header>Fun Fact!</Popover.Header>
+    <Popover.Body>
+      The new Texas Instrument calculators have ABC keyboards because if
+      they had QWERTY keyboards, they would be considered computers and
+      wouldn’t be allowed for standardized test taking
+    </Popover.Body>
+  </Popover.Content>
+</Popover>
+<Popover>
+  <Popover.Trigger color="primary" outline>
+    Popover Right
+  </Popover.Trigger>
+  <Popover.Content right>
+    <Popover.Header>Fun Fact!</Popover.Header>
+    <Popover.Body>
+      The new Texas Instrument calculators have ABC keyboards because if
+      they had QWERTY keyboards, they would be considered computers and
+      wouldn’t be allowed for standardized test taking
+    </Popover.Body>
+  </Popover.Content>
+</Popover>
+<Popover>
+  <Popover.Trigger color="primary" outline>
+    Popover Bottom
+  </Popover.Trigger>
+  <Popover.Content bottom>
+    <Popover.Header>Fun Fact!</Popover.Header>
+    <Popover.Body>
+      The new Texas Instrument calculators have ABC keyboards because if
+      they had QWERTY keyboards, they would be considered computers and
+      wouldn’t be allowed for standardized test taking
+    </Popover.Body>
+  </Popover.Content>
+</Popover>
+<Popover>
+  <Popover.Trigger color="primary" outline>
+    Popover Left
+  </Popover.Trigger>
+  <Popover.Content left>
     <Popover.Header>Fun Fact!</Popover.Header>
     <Popover.Body>
       The new Texas Instrument calculators have ABC keyboards because if

--- a/src/components/ComponentsScreen/TooltipsScreen/Tooltips.md
+++ b/src/components/ComponentsScreen/TooltipsScreen/Tooltips.md
@@ -1,12 +1,12 @@
 <p className="lead">Tooltip component...</p>
 <Tooltip>
-  <Tooltip.Trigger>Tooltip Trigger</Tooltip.Trigger>
+  <Tooltip.Trigger>Tooltip</Tooltip.Trigger>
   <Tooltip.Content>
     Only 8% of the world’s currency is physical money, the rest only exists
     on computers.
   </Tooltip.Content>
 </Tooltip>
 <Tooltip
-  Trigger="Tooltip Trigger"
-  Content="Only 8% of the world’s currency is physical money, the rest only exists on computers."
+  Trigger="Tooltip"
+  Content="Only 8%!"
 />


### PR DESCRIPTION
ISSUES CLOSED: #10 

Poppers now use a content container to create a positioned ancestor with width equal to popper max, this allows removal of hacky width calculations within the content component to get the correct display width.

<!--
  👋 Hello friend, thank you for contributing to Componentry, you are AWESOME 😍
  Please use this helpful template for filing Pull Requests. (the CONTRIBUTING
  guide contains motivation on these detials).
-->

<!-- PR Summary -->



## Requirements

* [x] PR is targeted against `develop` branch
* [x] Commit messages created with `commitizen` <!-- hint: npm run commit -->
* [x] Tests added for changes
* [x] All tests are _definitely_ passing <!-- hint: npm test -->
