### PR TITLE
fix(components): fix popover alignment styles 👍

### DIFF
--- a/demo/styles/theme.scss
+++ b/demo/styles/theme.scss
@@ -87,6 +87,7 @@ $tooltip-arrow-height: 8px;
 // Popovers
 
 $popover-box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.2);
+$popover-arrow-width: 11px;
 
 // Modals
 // ---------------------------------------------------------------------------

--- a/src/Popover/popover.scss
+++ b/src/Popover/popover.scss
@@ -31,13 +31,12 @@
     }
 
     .tip-container {
-      left: 0;
       top: 100%;
       width: 100%;
     }
 
     .tip:after {
-      bottom: $popover-arrow-width * 1.5;
+      bottom: $popover-arrow-width * 0.5;
     }
   }
 
@@ -52,13 +51,12 @@
     }
 
     .tip-container {
-      left: -$popover-arrow-width * 2;
       height: 100%;
-      top: 0.5em; // We want the tip to be 1/2 of line height from the top for perfect center
+      right: 100%;
     }
 
     .tip:after {
-      left: $popover-arrow-width * 1.5;
+      left: $popover-arrow-width * 0.5;
     }
   }
 
@@ -74,12 +72,11 @@
 
     .tip-container {
       bottom: 100%;
-      left: 0;
       width: 100%;
     }
 
     .tip:after {
-      top: $popover-arrow-width * 1.5;
+      top: $popover-arrow-width * 0.5;
     }
   }
 
@@ -91,16 +88,16 @@
 
     .popover-content {
       margin-right: $popover-arrow-width;
+      right: 0;
     }
 
     .tip-container {
       height: 100%;
-      right: -$popover-arrow-width * 2;
-      top: 0.5em; // We want the tip to be 1/2 of line height from the top for perfect center
+      left: 100%;
     }
 
     .tip:after {
-      right: $popover-arrow-width * 1.5;
+      right: $popover-arrow-width * 0.5;
     }
   }
 }
@@ -137,10 +134,13 @@
     position: absolute;
   }
 
+  // The .tip container creates a containing box of the same height and width as the
+  // tip with overflow hidden. Then inside that container we create a square of the
+  // same dimensions, and rotate it 45 degrees to create the tip effect
   .tip {
-    height: $popover-arrow-width * 2;
+    height: $popover-arrow-width;
     overflow: hidden;
-    width: $popover-arrow-width * 2;
+    width: $popover-arrow-width;
 
     &:after {
       border: $popover-border-width solid $popover-border-color;


### PR DESCRIPTION
Fixes alignment of the popover content for direction left popovers without content that fills the
max-width. Also includes cleaned up styles for creating popover tips.


## Requirements

* [x] PR is pointed to `develop` branch
* [x] Commit messages created with `commitizen` <!-- hint: npm run commit -->
* [x] Tests added for changes
* [x] All tests are _definitely_ passing <!-- hint: npm test -->
