### PR TITLE
fix(styles): remove invalid and unnecessary extend 👍

### DIFF
--- a/styles/componentry/_icons.scss
+++ b/styles/componentry/_icons.scss
@@ -5,8 +5,6 @@
 // icon system and set $include-icons to false to use real SVGs for icons.
 @if $include-icons {
   .icon.close {
-    @extend .componentry-icon;
-
     background-image: str-replace(
       url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$body-color}' viewBox='0 0 32 32'%3E%3Cpath d='M32,3.22,19.22,16,32,28.78,28.78,32,16,19.22,3.22,32,0,28.78,12.78,16,0,3.22,3.22,0,16,12.78,28.78,0Z'/%3E%3C/svg%3E"),
       '#',
@@ -15,8 +13,6 @@
   }
 
   .icon.chevron {
-    @extend .componentry-icon;
-
     background-image: str-replace(
       url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$link-color}' viewBox='0 0 32 32'%3E%3Cpath d='M6.71,8.51,16,17.8l9.29-9.29,2.84,2.84L16,23.49,3.86,11.35Z'/%3E%3C/svg%3E"),
       '#',


### PR DESCRIPTION
This extend is no longer needed now that there are icon styles in the library