### PR TITLE
Refactor/button defaults

### DIFF
--- a/demo/components/ComponentsScreen/Screens/Drawers.md
+++ b/demo/components/ComponentsScreen/Screens/Drawers.md
@@ -22,7 +22,7 @@ component.
   renderCode={() => `<Drawer>
   <Card>
     <Card.Header>
-      <Flex as={Drawer.Trigger} align="center" justify="between" link className="w-100">
+      <Flex as={Drawer.Trigger} align="center" justify="between" className="w-100">
         <span>Trigger Drawer</span>
         <Icon id="chevron" />
       </Flex>
@@ -41,7 +41,7 @@ component.
       <Drawer>
         <Card>
           <Card.Header>
-            <Flex as={Drawer.Trigger} align="center" justify="between" link className="w-100">
+            <Flex as={Drawer.Trigger} align="center" justify="between" className="w-100">
               <span>Trigger Drawer</span>
               <Icon id="chevron" />
             </Flex>
@@ -74,7 +74,7 @@ inside an accordion.
   renderCode={() => `<Accordion>
   <Card>
     <Card.Header>
-      <Accordion.Trigger activeId="one" link>Trigger One</Accordion.Trigger>
+      <Accordion.Trigger activeId="one">Trigger One</Accordion.Trigger>
     </Card.Header>
     <Accordion.Content as={Card.Body} activeId="one">
         Content One
@@ -82,7 +82,7 @@ inside an accordion.
   </Card>
   <Card>
     <Card.Header>
-      <Accordion.Trigger activeId="two" link>Trigger Two</Accordion.Trigger>
+      <Accordion.Trigger activeId="two">Trigger Two</Accordion.Trigger>
     </Card.Header>
     <Accordion.Content as={Card.Body} activeId="two">
         Content Two
@@ -90,7 +90,7 @@ inside an accordion.
   </Card>
   <Card>
     <Card.Header>
-      <Accordion.Trigger activeId="three" link>Trigger Three</Accordion.Trigger>
+      <Accordion.Trigger activeId="three">Trigger Three</Accordion.Trigger>
     </Card.Header>
     <Accordion.Content as={Card.Body} activeId="three">
         Content Three
@@ -102,7 +102,7 @@ inside an accordion.
       <Accordion>
         <Card>
           <Card.Header>
-            <Accordion.Trigger activeId="one" link>Trigger One</Accordion.Trigger>
+            <Accordion.Trigger activeId="one">Trigger One</Accordion.Trigger>
           </Card.Header>
           <Accordion.Content as={Card.Body} activeId="one">
               Content One
@@ -110,7 +110,7 @@ inside an accordion.
         </Card>
         <Card>
           <Card.Header>
-            <Accordion.Trigger activeId="two" link>Trigger Two</Accordion.Trigger>
+            <Accordion.Trigger activeId="two">Trigger Two</Accordion.Trigger>
           </Card.Header>
           <Accordion.Content as={Card.Body} activeId="two">
               Content Two
@@ -118,7 +118,7 @@ inside an accordion.
         </Card>
         <Card>
           <Card.Header>
-            <Accordion.Trigger activeId="three" link>Trigger Three</Accordion.Trigger>
+            <Accordion.Trigger activeId="three">Trigger Three</Accordion.Trigger>
           </Card.Header>
           <Accordion.Content as={Card.Body} activeId="three">
               Content Three

--- a/demo/components/ComponentsScreen/Screens/Dropdowns.md
+++ b/demo/components/ComponentsScreen/Screens/Dropdowns.md
@@ -24,6 +24,9 @@ enable easy navigation between multiple options.
     <h4 className="dropdown-header">Available actions</h4>
     <Dropdown.Item>Interactive Item 1</Dropdown.Item>
     <Dropdown.Item>Interactive Item 2</Dropdown.Item>
+    <Dropdown.Item onClick={() => console.log('hi')} disabled>
+      Disabled Item
+    </Dropdown.Item>
     <div className="dropdown-divider" />
     <span className="dropdown-item-text">Dropdown item text is not interactive</span>
   </Dropdown.Content>
@@ -35,6 +38,9 @@ enable easy navigation between multiple options.
         <h4 className="dropdown-header">Available actions</h4>
         <Dropdown.Item>Interactive Item 1</Dropdown.Item>
         <Dropdown.Item>Interactive Item 2</Dropdown.Item>
+        <Dropdown.Item onClick={() => console.log('hi')} disabled>
+          Disabled Item
+        </Dropdown.Item>
         <div className="dropdown-divider" />
         <span className="dropdown-item-text">Dropdown item text is not interactive</span>
       </Dropdown.Content>

--- a/demo/components/ComponentsScreen/Screens/Lists.md
+++ b/demo/components/ComponentsScreen/Screens/Lists.md
@@ -15,18 +15,39 @@ The List will automatically render a `ul` and child `li` tags for lists of
 elements without user interactions. Including a `href` or `onClick` wil return a
 `div` with appropriate `a` or `Button` components for list items.
 
+Note that list group items should *not* render the `btn` class. They are
+separate components with distinct classes and styles!
+
 <InteractiveDemo
-  renderCode={() => `<List>
+  renderCode={() => `<Header as="h4" mt={3}>List Items</Header>
+<List>
   <List.Item>Item One</List.Item>
   <List.Item active>Item Two</List.Item>
   <List.Item>Item Three</List.Item>
+  <List.Item disabled>Disabled</List.Item>
+</List>
+<Header as="h4" mt={3}>Action List Items</Header>
+<List>
+  <List.Item onClick={() => {}}>Button One</List.Item>
+  <List.Item active onClick={() => {}}>Button Two</List.Item>
+  <List.Item onClick={() => {}}>Button Three</List.Item>
+  <List.Item onClick={() => {}} disabled>Disabled</List.Item>
 </List>`}
   renderComponent={() => (
     <div className="w-50">
+      <Header as="h4" mt={3}>List Items</Header>
       <List>
         <List.Item>Item One</List.Item>
         <List.Item active>Item Two</List.Item>
         <List.Item>Item Three</List.Item>
+        <List.Item disabled>Disabled</List.Item>
+      </List>
+      <Header as="h4" mt={3}>Action List Items</Header>
+      <List>
+        <List.Item onClick={() => {}}>Button One</List.Item>
+        <List.Item active onClick={() => {}}>Button Two</List.Item>
+        <List.Item onClick={() => {}}>Button Three</List.Item>
+        <List.Item onClick={() => {}} disabled>Disabled</List.Item>
       </List>
     </div>
   )}

--- a/demo/components/ComponentsScreen/Screens/Navs.md
+++ b/demo/components/ComponentsScreen/Screens/Navs.md
@@ -28,6 +28,10 @@ options for composing navigation into other components. By default the Nav
 component creates a `nav` tag with either `a` or Button elements for nav items,
 but the tags used can be specified using the `as` prop.
 
+Like the `List.Item` component, the `Nav.Item` has a base class `nav-item` that
+is added to any element. The modifier `nav-item-action` is added to button and
+anchor elements to provide user interaction styles.
+
 <InteractiveDemo
   defaults={{ fill: false, justify: false, pills: false, vertical: false }}
   formFields={[
@@ -37,16 +41,18 @@ but the tags used can be specified using the `as` prop.
     { label: 'vertical', boolean: true },
   ]}
   renderCode={({ fill, justify, pills, vertical }) => `<Nav${pills ? ' pills' : ''}${vertical ? ' vertical' : ''}${fill ? ' fill' : ''}${justify ? ' justify' : ''}>
-  <Nav.Item href="#" active>Item 1</Nav.Item>
-  <Nav.Item href="#">Item 2</Nav.Item>
-  <Nav.Item href="#">Item 3</Nav.Item>
+  <Nav.Item href="#" active>Active</Nav.Item>
+  <Nav.Item href="#">Link</Nav.Item>
+  <Nav.Item onClick={() => console.log('hi')}>Link</Nav.Item>
+  <Nav.Item href="#" disabled>Disabled</Nav.Item>
 </Nav>`}
   renderComponent={({ fill, justify, pills, vertical }) => (
     <div className="w-75">
       <Nav pills={pills} vertical={vertical} fill={fill} justify={justify}>
-        <Nav.Item href="#" active>Item 1</Nav.Item>
-        <Nav.Item href="#">Item 2</Nav.Item>
-        <Nav.Item href="#">Item 3</Nav.Item>
+        <Nav.Item href="#" active>Active</Nav.Item>
+        <Nav.Item href="#">Link</Nav.Item>
+        <Nav.Item onClick={() => console.log('hi')}>Link</Nav.Item>
+        <Nav.Item href="#" disabled>Disabled</Nav.Item>
       </Nav>
     </div>
   )}

--- a/demo/components/ComponentsScreen/Screens/Tabs.md
+++ b/demo/components/ComponentsScreen/Screens/Tabs.md
@@ -1,3 +1,14 @@
+---
+componentProps:
+  - name: fill
+    description: Toggles the fill style so that nav items fill the nav container based on their width.
+    type: boolean
+    defaultValue: "false"
+  - name: justify
+    description: Togles the justify styles so that nav items fill the nav container using an equal width.
+    defaultValue: "false"
+    type: boolean
+---
 <ComponentsList
   components={[
     "Tab",
@@ -16,38 +27,45 @@ multiple active components within the Active component, and the `activeId` used
 by a trigger and content pane must match.
 
 <InteractiveDemo
-  renderCode={() => `<Tab defaultActive="one">
-  <Tab.Nav className="mb-3">
+  defaults={{ fill: false, justify: false }}
+  formFields={[
+    { label: 'fill', boolean: true },
+    { label: 'justify', boolean: true }
+  ]}
+  renderCode={({ fill, justify }) => `<Tab defaultActive="one" className="w-100">
+  <Tab.Nav${fill ? ' fill' : ''}${justify ? ' justify' : ''}>
     <Tab.Trigger activeId="one">Item 1</Tab.Trigger>
-    <Tab.Trigger activeId="two">Item 2</Tab.Trigger>
+    <Tab.Trigger activeId="two">Tab with long name</Tab.Trigger>
     <Tab.Trigger activeId="three">Item 3</Tab.Trigger>
+    <Tab.Trigger activeId="four" disabled>Disabled</Tab.Trigger>
   </Tab.Nav>
   <Tab.ContentContainer>
     <Tab.Content activeId="one">Tab 1</Tab.Content>
     <Tab.Content activeId="two">Tab 2</Tab.Content>
     <Tab.Content activeId="three">Tab 3</Tab.Content>
+    <Tab.Content activeId="four">This tab has been disabled</Tab.Content>
   </Tab.ContentContainer>
 </Tab>`}
-  renderComponent={() => (
-    <div className="w-50">
-      <Tab defaultActive="one">
-        <Tab.Nav className="mb-3">
-          <Tab.Trigger activeId="one">Item 1</Tab.Trigger>
-          <Tab.Trigger activeId="two">Item 2</Tab.Trigger>
-          <Tab.Trigger activeId="three">Item 3</Tab.Trigger>
-        </Tab.Nav>
-        <Tab.ContentContainer>
-          <Tab.Content activeId="one">Tab 1</Tab.Content>
-          <Tab.Content activeId="two">Tab 2</Tab.Content>
-          <Tab.Content activeId="three">Tab 3</Tab.Content>
-        </Tab.ContentContainer>
-      </Tab>
-    </div>
+  renderComponent={({ fill, justify }) => (
+    <Tab defaultActive="one" className="w-100">
+      <Tab.Nav fill={fill} justify={justify}>
+        <Tab.Trigger activeId="one">Item 1</Tab.Trigger>
+        <Tab.Trigger activeId="two">Tab with long name</Tab.Trigger>
+        <Tab.Trigger activeId="three">Item 3</Tab.Trigger>
+        <Tab.Trigger activeId="four" disabled>Disabled</Tab.Trigger>
+      </Tab.Nav>
+      <Tab.ContentContainer>
+        <Tab.Content activeId="one">Tab 1</Tab.Content>
+        <Tab.Content activeId="two">Tab 2</Tab.Content>
+        <Tab.Content activeId="three">Tab 3</Tab.Content>
+        <Tab.Content activeId="four">This tab has been disabled</Tab.Content>
+      </Tab.ContentContainer>
+    </Tab>
   )}
 />
 
 <SupportingInfo apis={['Active component', 'Nav component']} />
 
-<PropsTabs activeComponent />
+<PropsTabs activeComponent componentProps={componentProps} />
 
 

--- a/demo/components/HomeScreen/HomeScreen.js
+++ b/demo/components/HomeScreen/HomeScreen.js
@@ -49,18 +49,18 @@ export default () => (
       justify="center"
       className="border border-right-0 border-left-0 mb-4"
     >
-      <div className="m-3">
+      <div className="my-3 mx-2">
         <Link to={routesMap.setup.pathname}>{routesMap.setup.name}</Link>
       </div>
-      <div className="my-3">
+      <div className="my-3 mx-2">
         {/* Library concepts guides navigation */}
         <SubRoutesNav label="Concepts" subRoutes={conceptRoutes} />
       </div>
-      <div className="my-3">
+      <div className="my-3 mx-2">
         {/* Component dropdown navigation */}
         <SubRoutesNav label="Components" subRoutes={componentRoutes} />
       </div>
-      <div className="m-3">
+      <div className="my-3 mx-2">
         <a href="https://github.com/crystal-ball/componentry">Github</a>
       </div>
     </Flex>

--- a/demo/components/universal/AppNav/AppNav.js
+++ b/demo/components/universal/AppNav/AppNav.js
@@ -12,39 +12,30 @@ import { component } from './app-nav.scss'
 /**
  * App navigation is shown on pages that are not home or component guides.
  */
-export default () => (
+const AppNav = () => (
   <Flex as="header" justify="between" className={`${component} bg-gray-100 p-4 mb-5`}>
-    {/* Home route */}
-    <Flex>
-      <Flex align="center" className="pr-3">
-        <Link to="/" className="text-primary logo">
-          <u>C</u>
-          omponentry
-        </Link>
-      </Flex>
-    </Flex>
+    <Link to="/" className="text-primary logo">
+      <u>C</u>
+      omponentry
+    </Link>
 
     <Flex align="center">
-      {/* Library setup */}
-      <Anchor to={routesMap.setup.pathname} className="text-primary pr-2">
+      <Anchor to={routesMap.setup.pathname} className="text-primary pr-3">
         {routesMap.setup.name}
       </Anchor>
 
-      {/* Concepts dropdown navigation */}
-      <SubRoutesNav label="Concepts" subRoutes={conceptRoutes} />
+      <SubRoutesNav label="Concepts" subRoutes={conceptRoutes} className="pr-3" />
 
-      {/* Component dropdown navigation */}
-      <SubRoutesNav label="Components" subRoutes={componentRoutes} />
+      <SubRoutesNav label="Components" subRoutes={componentRoutes} className="pr-3" />
 
-      {/* Github link */}
-      <div className="pl-3">
-        <Anchor
-          className="text-primary h2 hi friend"
-          href="https://github.com/crystal-ball/componentry"
-        >
-          <Icon id="github" font={false} />
-        </Anchor>
-      </div>
+      <Anchor
+        className="d-flex text-primary h2 mb-0"
+        href="https://github.com/crystal-ball/componentry"
+      >
+        <Icon id="github" font={false} />
+      </Anchor>
     </Flex>
   </Flex>
 )
+
+export default AppNav

--- a/demo/components/universal/InteractiveDemo/FormField/FormField.js
+++ b/demo/components/universal/InteractiveDemo/FormField/FormField.js
@@ -45,7 +45,7 @@ const FormField = ({
           onChange({ [label]: val })
         }}
       >
-        <Dropdown.Trigger link>{triggerValue}</Dropdown.Trigger>
+        <Dropdown.Trigger>{triggerValue}</Dropdown.Trigger>
         <Dropdown.Content>
           <Dropdown.Item value="none" className="font-italic font-weight-light">
             none

--- a/demo/components/universal/PropsTabs/PropsTabs.js
+++ b/demo/components/universal/PropsTabs/PropsTabs.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Flex, Icon, Nav, Tab } from 'componentry'
+import { Icon, Tab } from 'componentry'
 
 import TabContent from './TabContent'
 import { activeProps, componentryProps } from './props-content'
@@ -44,7 +44,8 @@ export default ({
       <h2 id="props">
         <Icon id="tune" /> Component props
       </h2>
-      <Flex as={Tab} defaultActive={defaultActive}>
+
+      <Tab className="d-flex" defaultActive={defaultActive}>
         <Tab.ContentContainer>
           {showComponentProps && (
             <Tab.Content activeId="Component">
@@ -60,14 +61,14 @@ export default ({
             </Tab.Content>
           )}
         </Tab.ContentContainer>
-        <Nav vertical className="ml-4">
+        <Tab.Nav vertical>
           {showComponentProps && (
             <Tab.Trigger activeId="Component">Component props</Tab.Trigger>
           )}
           <Tab.Trigger activeId="Componentry">Componentry props</Tab.Trigger>
           {activeComponent && <Tab.Trigger activeId="Active">Active props</Tab.Trigger>}
-        </Nav>
-      </Flex>
+        </Tab.Nav>
+      </Tab>
     </div>
   )
 }

--- a/demo/components/universal/PropsTabs/props-tabs.scss
+++ b/demo/components/universal/PropsTabs/props-tabs.scss
@@ -10,12 +10,6 @@
     min-height: 500px;
   }
 
-  // Create a sort of inverse pill nav for active highlighting
-  .nav-link.active {
-    border: 1px solid $primary;
-    color: $primary;
-  }
-
   tbody {
     font-size: 0.875rem;
   }

--- a/demo/components/universal/SubRoutesNav/SubRoutesNav.js
+++ b/demo/components/universal/SubRoutesNav/SubRoutesNav.js
@@ -4,12 +4,13 @@ import { Link } from 'react-router-dom'
 import { Dropdown } from 'componentry'
 
 type Props = {
+  className: string,
   label: string,
   subRoutes: Array<{ id: string, routeTo: {} }>,
 }
 
-const SubRoutesNav = ({ subRoutes, label }: Props) => (
-  <Dropdown as="nav">
+const SubRoutesNav = ({ className, subRoutes, label }: Props) => (
+  <Dropdown as="nav" className={className}>
     <Dropdown.Trigger color="link">{label}</Dropdown.Trigger>
     <Dropdown.Content className="dropdown-menu-right">
       {subRoutes.map(routeTo => (

--- a/demo/styles/application/app.scss
+++ b/demo/styles/application/app.scss
@@ -26,17 +26,6 @@
 
 // Do a fun 3d flip transition between open and closed states
 .dropdown-toggle {
-  &.btn-anchor {
-    border-bottom: 1px solid $dropdown-trigger-anchor-border-color;
-
-    // Add styles for inline dropdowns for a border bottom that matches the
-    // anchor color Helps the dropdown to stand out, even when used inline style
-    @include hover-focus {
-      border-bottom: 1px solid $dropdown-trigger-anchor-hover-border-color;
-      text-decoration: none; // Trigger border is the decoration
-    }
-  }
-
   .chevron.icon {
     transition: transform 500ms;
   }

--- a/src/Active/__snapshots__/Active.spec.js.snap
+++ b/src/Active/__snapshots__/Active.spec.js.snap
@@ -7,7 +7,7 @@ exports[`<Active /> snapshots renders correctly 1`] = `
 >
   <button
     aria-controls="guid"
-    class="btn active-toggle"
+    class="active-toggle btn-anchor"
     type="button"
   >
     Trigger

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -1,4 +1,3 @@
-// @flow
 import componentryElem from '../elem-factory'
 import withTheme from '../withTheme'
 import type { ThemeColors } from '../types'
@@ -7,7 +6,7 @@ export type Props = {
   /** Creates a full-width button */
   block?: boolean,
   /** Theme color used to compute BS color class */
-  color?: ThemeColors | 'link' | '',
+  color?: ThemeColors | 'link',
   /** Computes the button as anchor class */
   link?: boolean,
   /** Creates outline style button, uses `color` for outline theme. */
@@ -16,18 +15,26 @@ export type Props = {
   size?: 'small' | 'large',
 }
 
-const Button = ({ block, color = '', link, outline, size, ...rest }: Props) =>
+const Button = ({
+  block = false,
+  color,
+  link = false,
+  outline = false,
+  size,
+  ...rest
+}: Props) =>
   componentryElem({
     defaultAs: 'button',
     type: 'button',
     classes: {
-      btn: true,
+      btn: !link,
       'btn-anchor': link,
       'btn-block': block,
       [`btn-${color}`]: color,
       'btn-outline': outline,
       'btn-sm': size === 'small',
       'btn-lg': size === 'large',
+      disabled: rest.disabled,
     },
     ...rest,
   })

--- a/src/Button/__snapshots__/Button.spec.js.snap
+++ b/src/Button/__snapshots__/Button.spec.js.snap
@@ -29,7 +29,7 @@ exports[`<Button /> Snapshots it renders large outline correctly 1`] = `
 
 exports[`<Button /> Snapshots it renders link style correctly 1`] = `
 <button
-  class="btn btn-anchor"
+  class="btn-anchor"
   type="button"
 >
   Componentry

--- a/src/Button/button.scss
+++ b/src/Button/button.scss
@@ -7,7 +7,6 @@
 .btn {
   border: $btn-border-width solid transparent;
   @include border-radius($btn-border-radius);
-  cursor: pointer; // Opinionated: add pointer to non-disabled .btn elements
   display: inline-block;
   font-size: $font-size-base;
   font-weight: $btn-font-weight;
@@ -28,9 +27,7 @@
 
   // Default disabled styles remove pointer and adjust opacity to indicate
   // button is disabled
-  &.disabled,
-  &:disabled {
-    cursor: default;
+  &.disabled {
     opacity: $btn-disabled-opacity;
   }
 }
@@ -61,8 +58,7 @@
     // Disabled buttons can be styled to a consistent appearance with optional
     // disabled theme vars, otherwise reset to default appearance with an
     // opacity change to indicate disabled state
-    &.disabled,
-    &:disabled {
+    &.disabled {
       border-width: $btn-disabled-border-width;
 
       @if variable-exists(btn-disabled-bg) {
@@ -84,6 +80,28 @@
       }
     }
   }
+}
+
+// 'Link' theme color variant -  have the padding and alignment of a button with
+// font styles matching anchors (can be used for things like secondary CTAs)
+.btn-link {
+  background-color: transparent;
+  color: $link-color;
+  font-weight: $font-weight-normal;
+  // 🤔 Should btn-link reset the text tansform and letter spacing?
+
+  &:hover {
+    background-color: transparent;
+    border-color: transparent;
+    color: $link-hover-color;
+    text-decoration: $link-hover-decoration;
+  }
+
+  &.disabled {
+    color: $btn-link-disabled-color;
+  }
+
+  // No need for an active state here
 }
 
 //
@@ -111,67 +129,11 @@
       @include gradient-bg(darken($value, 7.5%));
     }
 
-    &.disabled,
-    &:disabled {
+    &.disabled {
       color: $value;
       background-color: transparent;
     }
   }
-}
-
-//
-// Link buttons
-//
-
-// Creates a button that has the text styles of an anchor, but maintains the
-// padding of a button, this is useful for adding secondary CTA buttons.
-.btn-link {
-  background-color: transparent;
-  color: $link-color;
-  font-weight: $font-weight-normal;
-  // 🤔 Should btn-link reset the text tansform and letter spacing?
-
-  &:hover {
-    background-color: transparent;
-    border-color: transparent;
-    color: $link-hover-color;
-    text-decoration: $link-hover-decoration;
-  }
-
-  &:disabled,
-  &.disabled {
-    color: $btn-link-disabled-color;
-    pointer-events: none;
-  }
-
-  // No need for an active state here
-}
-
-//
-// Anchor button
-//
-
-// The `.btn-link` style button has the font styles of an anchor AND all of the
-// regular padding of a button. For 💯 Accessibility we want to have buttons
-// that look exactly like links for in application triggers, `btn-anchor`
-// creates a button styled exactly like an anchor. This should be used for any
-// application actions that are not route navigations.
-
-.btn-anchor {
-  @extend .btn-link; // Extend link styles for font styling
-
-  // Remove additional button styles for anchor appearance
-  -webkit-appearance: none !important; // Remove Chrome native button styling
-  border: none;
-  border-radius: 0;
-  font-family: $font-family-sans-serif;
-  letter-spacing: 0;
-  line-height: $line-height-base;
-  padding: 0;
-  text-transform: none;
-  user-select: auto;
-  vertical-align: baseline;
-  white-space: normal;
 }
 
 //
@@ -216,6 +178,50 @@
 }
 
 //
+// Anchor button
+//
+
+// The `.btn-link` style button has the font styles of an anchor AND all of the
+// regular padding of a button. For 💯 Accessibility we want to have buttons
+// that look exactly like links for in application triggers, `btn-anchor`
+// creates a button styled exactly like an anchor. This should be used for any
+// application actions that are not route navigations.
+
+.btn-anchor {
+  -webkit-appearance: none !important; // Remove Chrome native button styling
+  display: inline-block;
+  padding: 0;
+  background-color: transparent;
+
+  // Set anchor font styles
+  color: $link-color;
+  font-family: $font-family-sans-serif;
+  font-size: $font-size-base;
+  font-weight: $font-weight-normal;
+  line-height: $line-height-base;
+  letter-spacing: 0;
+  text-transform: none;
+
+  user-select: auto;
+  vertical-align: baseline;
+  white-space: normal;
+
+  border: none;
+  border-radius: 0;
+
+  &:hover {
+    background-color: transparent;
+    border-color: transparent;
+    color: $link-hover-color;
+    text-decoration: $link-hover-decoration;
+  }
+
+  &.disabled {
+    color: $btn-link-disabled-color;
+  }
+}
+
+//
 // Block button
 //
 
@@ -229,14 +235,4 @@
   + .btn-block {
     margin-top: $btn-block-spacing-y;
   }
-}
-
-//
-// Disabled button style anchors
-//
-
-// Future-proof disabling of clicks on `<a>` elements
-a.btn.disabled,
-fieldset:disabled a.btn {
-  pointer-events: none;
 }

--- a/src/Button/button.scss
+++ b/src/Button/button.scss
@@ -63,16 +63,20 @@
     // opacity change to indicate disabled state
     &.disabled,
     &:disabled {
+      border-width: $btn-disabled-border-width;
+
       @if variable-exists(btn-disabled-bg) {
         @include gradient-bg($btn-disabled-bg);
       } @else {
         @include gradient-bg($value);
       }
+
       @if variable-exists(btn-disabled-border) {
         border-color: $btn-disabled-border;
       } @else {
         border-color: $value;
       }
+
       @if variable-exists(btn-disabled-color) {
         color: $btn-disabled-color;
       } @else {

--- a/src/Close/close.scss
+++ b/src/Close/close.scss
@@ -1,10 +1,5 @@
 /* componentry/src/Close/close */
 
-// ℹ️ Do not import Bootstrap close styles:
-// The Bootstrap close styles assume that you are using the &times; character for
-// your close button, and includes some styles to bump the font size, adjust line
-// line height and add a float.
-//
 // Componentry supports using an SVG icon so that applications can choose a close
 // icon that fits their theme, as well as using flexbox on containers with close
 // buttons instead of floats.
@@ -13,7 +8,6 @@
 // can also be styled for close buttons only using that as a target
 // ℹ️ The background image styles for close icons is located in `/styles/componentry/icons`
 .btn-close {
-  @extend .btn;
   @extend .btn-anchor;
 
   color: $close-color;

--- a/src/Drawers/__snapshots__/Drawers.spec.js.snap
+++ b/src/Drawers/__snapshots__/Drawers.spec.js.snap
@@ -8,7 +8,7 @@ exports[`<Drawer /> snapshots renders correctly 1`] = `
   <button
     aria-controls="guid"
     aria-expanded="false"
-    class="btn drawer-toggle"
+    class="drawer-toggle btn-anchor"
     type="button"
   >
     Trigger

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -18,6 +18,8 @@ const Item = activeTrigger({
   // TODO: what arias should this have?
   arias: {},
   classes: 'dropdown-item',
+  // Dropdown items have appropriate styles
+  defaultLink: false,
 })
 
 const Dropdown = activeContainer({

--- a/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -8,7 +8,7 @@ exports[`<Drawer /> snapshots renders correctly 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="btn dropdown-toggle"
+    class="dropdown-toggle btn-anchor"
     id="guid"
     type="button"
   >
@@ -20,13 +20,13 @@ exports[`<Drawer /> snapshots renders correctly 1`] = `
     class="dropdown-content"
   >
     <button
-      class="btn dropdown-item"
+      class="dropdown-item"
       type="button"
     >
       Item 1
     </button>
     <button
-      class="btn dropdown-item"
+      class="dropdown-item"
       type="button"
     >
       Item 2

--- a/src/Dropdown/dropdown.scss
+++ b/src/Dropdown/dropdown.scss
@@ -152,6 +152,7 @@
 
 // Dropdown items
 // `<button>`-specific styles are denoted with `// For <button>s`
+// TODO: handle cursors for buttons...
 .dropdown-item {
   display: block;
   width: 100%; // For `<button>`s
@@ -159,6 +160,7 @@
   font-weight: $font-weight-normal;
   color: $dropdown-link-color;
   text-align: inherit; // For `<button>`s
+  line-height: $dropdown-item-line-height;
   white-space: nowrap; // prevent links from randomly breaking onto new lines
   background-color: transparent; // For `<button>`s
   border: 0; // For `<button>`s
@@ -177,8 +179,7 @@
     @include gradient-bg($dropdown-link-active-bg);
   }
 
-  &.disabled,
-  &:disabled {
+  &.disabled {
     color: $dropdown-link-disabled-color;
     background-color: transparent;
     // Remove CSS gradients if they're enabled

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -1,11 +1,10 @@
-// @flow
 import { Children } from 'react'
 import elem from '../elem-factory'
 import withTheme from '../withTheme'
 
 /**
- * 🤔 There are different wrappers for clickable vs non-clickable list groups. (this
- * seems less than ideal Bootstrap, can we always do a div?)
+ * List checks first child (only first child!) to see if it has actions, and if
+ * it does, it's not a `li` so we render a `ul`.
  */
 
 const List = withTheme('List', props => {
@@ -20,6 +19,11 @@ const List = withTheme('List', props => {
   })
 })
 
+/**
+ * List items always have the `list-group-item` class, and items that are
+ * actionable (buttons/anchors) have the `list-group-item-action` modifier class
+ * added with additional required styles.
+ */
 const Item = withTheme('ListItem', ({ active, color, ...rest }) => {
   const { href, onClick } = rest
 
@@ -28,6 +32,7 @@ const Item = withTheme('ListItem', ({ active, color, ...rest }) => {
     defaultAs: href || onClick ? (href ? 'a' : 'button') : 'li',
     classes: {
       active,
+      disabled: rest.disabled,
       'list-group-item': true,
       'list-group-item-action': href || onClick,
       [`list-group-item-${color}`]: color,
@@ -35,6 +40,6 @@ const Item = withTheme('ListItem', ({ active, color, ...rest }) => {
     ...rest,
   })
 })
-List.Item = Item
 
+List.Item = Item
 export default List

--- a/src/List/list.scss
+++ b/src/List/list.scss
@@ -13,29 +13,6 @@
   margin-bottom: 0;
 }
 
-// Interactive list items
-//
-// Use anchor or button elements instead of `li`s or `div`s to create interactive
-// list items. Includes an extra `.active` modifier class for selected items.
-
-.list-group-item-action {
-  width: 100%; // For `<button>`s (anchors become 100% by default though)
-  color: $list-group-action-color;
-  text-align: inherit; // For `<button>`s (anchors inherit)
-
-  // Hover state
-  @include hover-focus {
-    color: $list-group-action-hover-color;
-    text-decoration: none;
-    background-color: $list-group-hover-bg;
-  }
-
-  &:active {
-    color: $list-group-action-active-color;
-    background-color: $list-group-action-active-bg;
-  }
-}
-
 // Individual list items
 //
 // Use on `li`s or `div`s within the `.list-group` parent.
@@ -63,19 +40,48 @@
     text-decoration: none;
   }
 
-  &.disabled,
-  &:disabled {
+  &.disabled {
     color: $list-group-disabled-color;
     background-color: $list-group-disabled-bg;
   }
+}
 
-  // Include both here for `<a>`s and `<button>`s
-  &.active {
-    z-index: 2; // Place active items above their siblings for proper border styling
-    color: $list-group-active-color;
-    background-color: $list-group-active-bg;
-    border-color: $list-group-active-border-color;
+// Interactive list items
+//
+// Use anchor or button elements instead of `li`s or `div`s to create interactive
+// list items. Includes an extra `.active` modifier class for selected items.
+
+.list-group-item-action {
+  width: 100%; // For `<button>`s (anchors become 100% by default though)
+  color: $list-group-action-color;
+  text-align: inherit; // For `<button>`s (anchors inherit)
+
+  // Hover state
+  @include hover-focus {
+    color: $list-group-action-hover-color;
+    text-decoration: none;
+    background-color: $list-group-hover-bg;
   }
+
+  // Note that the active state is different from having the active class
+  // (Class is persistent, state is for user interaction)
+  &:active {
+    color: $list-group-action-active-color;
+    background-color: $list-group-action-active-bg;
+  }
+}
+
+//
+// Active styles
+//
+
+// Must be declared after list-group-item-action ensure active has precedence
+// over :hover (Note this is valid for items and action items)
+.list-group-item.active {
+  z-index: 2; // Place active items above their siblings for proper border styling
+  color: $list-group-active-color;
+  background-color: $list-group-active-bg;
+  border-color: $list-group-active-border-color;
 }
 
 // Flush list items

--- a/src/Navs/Navs.js
+++ b/src/Navs/Navs.js
@@ -15,9 +15,9 @@ const makeNav = tabNav =>
       defaultAs: 'nav',
       role: tabNav ? 'tablist' : undefined,
       classes: {
-        nav: true,
-        'nav-tabs': tabNav,
-        'flex-column': vertical,
+        nav: !tabNav,
+        'tabs-nav-container': tabNav,
+        'nav-vertical': vertical,
         'nav-pills': pills,
         'nav-fill': fill,
         'nav-justified': justify,
@@ -29,6 +29,10 @@ const makeNav = tabNav =>
 const Nav = makeNav(false)
 const TabNav = makeNav(true)
 
+/**
+ * Nav items can be action items or li, notice this follows the same pattern as
+ * the List.Item components
+ */
 const Item = withTheme('NavItem', ({ active, ...rest }) => {
   const { href, onClick } = rest
 
@@ -37,8 +41,9 @@ const Item = withTheme('NavItem', ({ active, ...rest }) => {
     defaultAs: href || onClick ? (href ? 'a' : 'button') : 'li',
     classes: {
       active,
+      disabled: rest.disabled,
       'nav-item': true,
-      'nav-link': href || onClick,
+      'nav-item-action': href || onClick,
     },
     ...rest,
   })

--- a/src/Navs/Navs.spec.js
+++ b/src/Navs/Navs.spec.js
@@ -8,13 +8,13 @@ describe('<Nav />', () => {
   // Basic library element test suite
   elementTests(Nav)
 
-  test('should render .flex-column when vertical is passed', () => {
+  test('should render .nav-vertical when vertical is passed', () => {
     const wrapper = mount(
       <Nav vertical>
         <Nav.Item href="#">Anchor one</Nav.Item>
       </Nav>,
     )
-    expect(wrapper.find('nav.flex-column').length).toBeTruthy()
+    expect(wrapper.find('nav.nav-vertical').length).toBeTruthy()
   })
 
   test('should render .nav-pills when pills is passed', () => {

--- a/src/Navs/__snapshots__/Navs.spec.js.snap
+++ b/src/Navs/__snapshots__/Navs.spec.js.snap
@@ -5,7 +5,7 @@ exports[`<Nav /> snapshots renders correctly 1`] = `
   class="nav"
 >
   <a
-    class="nav-item nav-link"
+    class="nav-item nav-item-action"
     href="#"
   >
     Anchor one

--- a/src/Navs/navs.scss
+++ b/src/Navs/navs.scss
@@ -13,59 +13,12 @@
   list-style: none;
 }
 
-.nav-link {
-  display: block;
-  padding: $nav-link-padding-y $nav-link-padding-x;
-
-  @include hover-focus {
-    text-decoration: none;
-  }
-
-  // Disabled state lightens text
-  &.disabled {
-    color: $nav-link-disabled-color;
-  }
-}
-
 //
-// Tabs
+// Vertical
 //
 
-.nav-tabs {
-  border-bottom: $nav-tabs-border-width solid $nav-tabs-border-color;
-
-  .nav-item {
-    margin-bottom: -$nav-tabs-border-width;
-  }
-
-  .nav-link {
-    border: $nav-tabs-border-width solid transparent;
-    @include border-top-radius($nav-tabs-border-radius);
-
-    @include hover-focus {
-      border-color: $nav-tabs-link-hover-border-color;
-    }
-
-    &.disabled {
-      color: $nav-link-disabled-color;
-      background-color: transparent;
-      border-color: transparent;
-    }
-  }
-
-  .nav-link.active,
-  .nav-item.show .nav-link {
-    color: $nav-tabs-link-active-color;
-    background-color: $nav-tabs-link-active-bg;
-    border-color: $nav-tabs-link-active-border-color;
-  }
-
-  .dropdown-menu {
-    // Make dropdown border overlap tab border
-    margin-top: -$nav-tabs-border-width;
-    // Remove the top rounded corners here since there is a hard edge above the menu
-    @include border-top-radius(0);
-  }
+.nav-vertical {
+  flex-direction: column;
 }
 
 //
@@ -73,12 +26,11 @@
 //
 
 .nav-pills {
-  .nav-link {
+  .nav-item {
     @include border-radius($nav-pills-border-radius);
   }
 
-  .nav-link.active,
-  .show > .nav-link {
+  .nav-item.active {
     color: $nav-pills-link-active-color;
     background-color: $nav-pills-link-active-bg;
   }
@@ -100,5 +52,33 @@
     flex-basis: 0;
     flex-grow: 1;
     text-align: center;
+  }
+}
+
+//
+// Link elements
+//
+
+.nav-item {
+  -webkit-appearance: none;
+  border: none;
+  display: block;
+  padding: $nav-item-padding-y $nav-item-padding-x;
+  background: transparent;
+}
+
+.nav-item-action {
+  color: $nav-item-action-color;
+  text-align: left; // reset button font
+
+  @include hover-focus {
+    color: $nav-item-action-hover-color;
+    text-decoration: $nav-item-action-hover-decoration;
+  }
+
+  // Disabled state lightens text
+  &.disabled {
+    color: $nav-item-disabled-color;
+    text-decoration: none;
   }
 }

--- a/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -7,7 +7,7 @@ exports[`<Popover /> snapshots renders correctly 1`] = `
 >
   <button
     aria-describedby="guid"
-    class="btn popover-toggle"
+    class="popover-toggle btn-anchor"
     type="button"
   >
     Trigger

--- a/src/Tab/Tab.js
+++ b/src/Tab/Tab.js
@@ -10,34 +10,32 @@ import { TabNav } from '../Navs/Navs'
 
 const ContentContainer = withTheme('TabContentContainer', props =>
   elem({
-    classes: 'tab-panes-container',
+    classes: 'tabs-panes-container',
     ...props,
   }),
 )
 
 const Content = activeContent({
   arias: { hidden: true, role: 'tabpanel' },
-  classes: 'tab-pane',
+  classes: 'tabs-panes-pane',
 })
 
+// TODO: This should probably be defaultAs a nav item... issues:
+// If making a tab with anchors, these should have class 'nav-link'
 const Trigger = activeTrigger({
   arias: { selected: true, role: 'tab' },
   // TODO: Should this really have default nav-link and nav-item classes??
-  classes: 'tab-toggle nav-link nav-item',
+  classes: 'tabs-nav-tab',
   // Tabs can only activate, they never deactivate when clicked
   triggerType: 'activate',
+  // Do NOT include default btn styles in tabs
+  defaultLink: false,
 })
-Trigger.defaultProps = {
-  // Componentry uses <Button /> components for the tab triggers instead of
-  // anchors like Bootstrap. Default the button to have the link theme style to
-  // look like an anchor
-  color: 'link',
-}
 
 const Tab = activeContainer({
   Content: withActive(withTheme('TabContent', Content)),
   Trigger: withActive(withTheme('TabTrigger', Trigger)),
-  classes: 'tab',
+  classes: 'tabs',
 })
 
 Tab.Nav = TabNav

--- a/src/Tab/tab.scss
+++ b/src/Tab/tab.scss
@@ -1,3 +1,120 @@
 /* componentry/src/Tab/tab */
 
-// Tabs don't come with any styles yet
+//
+// Tabs
+//
+
+// --- Structure
+// .tabs
+// .tabs-panes-container
+// .tabs-panes-pane
+// .tabs-nav-container
+// .tabs-nav-tab
+
+//
+// Tabs container
+//
+
+// Container handles: margin between tabs and panes, and layout of tabs
+.tabs-nav-container {
+  display: flex;
+  margin: $tabs-nav-container-margin;
+  border-bottom: $tabs-nav-container-border;
+  background: $tabs-nav-container-bg;
+  box-shadow: $tabs-nav-container-shadow;
+
+  &.nav-fill {
+    .tabs-nav-tab {
+      flex: 1 1 auto;
+      text-align: center;
+    }
+  }
+
+  &.nav-justified {
+    .tabs-nav-tab {
+      flex-basis: 0;
+      flex-grow: 1;
+      text-align: center;
+    }
+  }
+
+  // vertical is applied with .nav-vertical
+}
+
+//
+// Tabs
+//
+
+// NOTE: Tabs are assumed to be an anchor or button element for accessibility!
+.tabs-nav-tab {
+  -webkit-appearance: none; // reset buttons
+  white-space: nowrap;
+  padding: $tabs-tab-padding-y $tabs-tab-padding-x;
+  background: $tabs-tab-bg;
+  color: $tabs-tab-color;
+  border-style: solid;
+  border-color: $tabs-tab-border-color;
+  border-width: $tabs-tab-border-width;
+  border-radius: $tabs-tab-border-radius;
+
+  transition: $tabs-tab-transition;
+
+  &:hover,
+  &:focus {
+    color: $tabs-tab-hover-color;
+    background: $tabs-tab-hover-bg;
+    border-color: $tabs-tab-hover-border-color;
+  }
+
+  &.active {
+    background: $tabs-tab-active-bg;
+    border-color: $tabs-tab-active-border-color;
+    color: $tabs-tab-active-color;
+  }
+
+  &.disabled {
+    background: $tabs-tab-disabled-bg;
+    border-color: $tabs-tab-disabled-border-color;
+    color: $tabs-tab-disabled-color;
+  }
+}
+
+// Provide ability to customize tab styles for vertical tabs, they likely look
+// different
+.tabs-nav-container.nav-vertical {
+  margin: $tabs-nav-vertical-margin;
+  border-bottom: none;
+
+  .tabs-nav-tab {
+    margin: $tabs-tab-vertical-margin;
+    border-width: $tabs-tab-vertical-border-width;
+    border-color: $tabs-tab-vertical-border-color;
+    border-radius: $tabs-tab-vertical-border-radius;
+
+    transition: $tabs-tab-vertical-transition;
+
+    &:hover,
+    &:focus {
+      border-width: $tabs-tab-vertical-hover-border-width;
+      border-color: $tabs-tab-vertical-hover-border-color;
+    }
+
+    &.active {
+      border-width: $tabs-tab-vertical-active-border-width;
+      border-color: $tabs-tab-vertical-active-border-color;
+    }
+
+    &.disabled {
+      border-width: $tabs-tab-vertical-disabled-border-width;
+      border-color: $tabs-tab-vertical-disabled-border-color;
+    }
+  }
+}
+
+//
+// Tab panes container
+//
+
+.tabs-panes-container {
+  padding: $tabs-pane-container-padding;
+}

--- a/src/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -7,7 +7,7 @@ exports[`<Drawer /> snapshots renders correctly 1`] = `
 >
   <button
     aria-describedby="guid"
-    class="btn tooltip-toggle"
+    class="tooltip-toggle btn-anchor"
     type="button"
   >
     Trigger

--- a/src/Type/Type.js
+++ b/src/Type/Type.js
@@ -19,41 +19,29 @@ type Props = {
  * The type elements share the same props API and are only different in the
  * default `as` value which is customized with default props.
  */
-const makeType = as => {
-  const Type = ({
-    color,
-    fontSize,
-    fontWeight,
-    italic,
-    letterSpacing,
-    lineHeight,
-    uppercase,
-    textAlign,
-    ...rest
-  }: Props) =>
-    elem({
-      style: { fontSize, letterSpacing, lineHeight },
-      classes: {
-        'font-italic': italic,
-        'text-uppercase': uppercase,
-        [`font-weight-${fontWeight}`]: fontWeight,
-        [`text-${color}`]: color,
-        [`text-${textAlign}`]: textAlign,
-      },
-      ...rest,
-    })
-
-  Type.defaultProps = {
-    as,
-    color: '',
-    fontWeight: '',
-    italic: false,
-    textAlign: '',
-    uppercase: false,
-  }
-
-  return Type
-}
+const makeType = as => ({
+  color,
+  fontSize,
+  fontWeight,
+  italic = false,
+  letterSpacing,
+  lineHeight,
+  uppercase = false,
+  textAlign,
+  ...rest
+}: Props) =>
+  elem({
+    defaultAs: as,
+    style: { fontSize, letterSpacing, lineHeight },
+    classes: {
+      'font-italic': italic,
+      'text-uppercase': uppercase,
+      [`font-weight-${fontWeight}`]: fontWeight,
+      [`text-${color}`]: color,
+      [`text-${textAlign}`]: textAlign,
+    },
+    ...rest,
+  })
 
 const Anchor = withTheme('Anchor', makeType('a'))
 const Header = withTheme('Header', makeType('h1'))

--- a/src/Type/anchor.scss
+++ b/src/Type/anchor.scss
@@ -9,4 +9,7 @@ a {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
   }
+
+  // ⚠️ Any styles added to anchors should be mirrored in the `btn-anchor`
+  // class
 }

--- a/src/active-trigger-factory.js
+++ b/src/active-trigger-factory.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Fragment, type Node } from 'react'
 import elem from './elem-factory'
-import Button from './Button/Button'
 import ariasComputer, { type ComponentArias } from './utils/arias'
 
 type Options = {
@@ -23,12 +22,20 @@ type Props = {
   active: boolean,
   deactivate: Function,
   guid: string,
+  /**
+   * Toggle `btn-anchor` utility class to style button as an anchor. Defaulted
+   * to true, this is the only button prop currently being handled. Pass the
+   * Button component for any `as` to use all button props.
+   */
+  link: boolean,
 }
 
 /**
  * Factory returns custom `<Trigger />` components defined by the options.
+ * Componentry sets up triggers to be anchor style buttons by default, this
+ * can be overridden by passing an as, type and link to reset the defaults.
  */
-export default ({ arias, classes, triggerType }: Options = {}) => ({
+export default ({ arias, classes, triggerType, defaultLink = true }: Options = {}) => ({
   activate,
   active,
   activeId = '',
@@ -36,6 +43,7 @@ export default ({ arias, classes, triggerType }: Options = {}) => ({
   deactivate,
   decoration,
   guid,
+  link,
   ...rest
 }: Props) => {
   let onClick
@@ -48,7 +56,8 @@ export default ({ arias, classes, triggerType }: Options = {}) => ({
   }
 
   return elem({
-    defaultAs: Button,
+    defaultAs: 'button',
+    type: 'button',
     ...ariasComputer({
       active,
       activeId,
@@ -61,6 +70,8 @@ export default ({ arias, classes, triggerType }: Options = {}) => ({
       {
         // For mutli-active triggers add active if the trigger is selected
         active: activeId && active === activeId,
+        disabled: rest.disabled,
+        'btn-anchor': link || defaultLink,
       },
     ],
     onClick,

--- a/styles/_initialize.scss
+++ b/styles/_initialize.scss
@@ -6,3 +6,36 @@
 
 @import 'initialize/reboot';
 @import 'initialize/css-variables';
+
+//
+// Focus outlines
+//
+
+body.suppress-outline {
+  & a:focus {
+    outline: none;
+  }
+  & button:focus {
+    outline: none;
+  }
+  & input:focus {
+    outline: none;
+  }
+  & select:focus {
+    outline: none;
+  }
+  & textarea:focus {
+    outline: none;
+  }
+}
+
+//
+// Disabled
+//
+
+.disabled {
+  // Ensure that disabled elements cannot be interacted with (and reset cursor
+  // styles to initial), individual elements should add specific disabled styles
+  // for color, bg, etc.
+  pointer-events: none;
+}

--- a/styles/content/_navbar.scss
+++ b/styles/content/_navbar.scss
@@ -81,8 +81,8 @@
 
 .navbar-text {
   display: inline-block;
-  padding-top: $nav-link-padding-y;
-  padding-bottom: $nav-link-padding-y;
+  padding-top: $nav-item-padding-y;
+  padding-bottom: $nav-item-padding-y;
 }
 
 // Responsive navbar

--- a/styles/initialize/_reboot.scss
+++ b/styles/initialize/_reboot.scss
@@ -290,6 +290,7 @@ th {
 
 button {
   -webkit-appearance: button;
+  cursor: pointer; // Opinionated: add pointer to non-disabled .btn elements
   margin: 0; // Remove the margin in Firefox and Safari
   font-family: inherit;
   font-size: inherit;
@@ -473,26 +474,4 @@ template {
 // Needed for proper display in IE 10-.
 [hidden] {
   display: none !important;
-}
-
-//
-// Focus outline handlers
-//
-
-body.suppress-outline {
-  & a:focus {
-    outline: none;
-  }
-  & button:focus {
-    outline: none;
-  }
-  & input:focus {
-    outline: none;
-  }
-  & select:focus {
-    outline: none;
-  }
-  & textarea:focus {
-    outline: none;
-  }
 }

--- a/styles/theme/_variables.scss
+++ b/styles/theme/_variables.scss
@@ -627,6 +627,7 @@ $dropdown-link-disabled-color:      $gray-600 !default;
 
 $dropdown-item-padding-y:           .25rem !default;
 $dropdown-item-padding-x:           1.5rem !default;
+$dropdown-item-line-height:         $line-height-base !default;
 
 $dropdown-header-color:             $gray-600 !default;
 
@@ -649,9 +650,13 @@ $zindex-tooltip:                    1070 !default;
 
 // Navs
 
-$nav-link-padding-y:                .5rem !default;
-$nav-link-padding-x:                1rem !default;
-$nav-link-disabled-color:           $gray-600 !default;
+$nav-item-padding-y:                .5rem !default;
+$nav-item-padding-x:                1rem !default;
+$nav-item-action-color:             $link-color !default;
+$nav-item-action-hover-color:       $link-hover-color !default;
+$nav-item-action-hover-decoration:  underline !default;
+
+$nav-item-disabled-color:           $gray-600 !default;
 
 $nav-tabs-border-color:             $gray-300 !default;
 $nav-tabs-border-width:             $border-width !default;
@@ -668,6 +673,60 @@ $nav-pills-link-active-bg:          $component-active-bg !default;
 $nav-divider-color:                 $gray-200 !default;
 $nav-divider-margin-y:              ($spacer / 2) !default;
 
+//
+// --- Tabs
+//
+
+$tabs-nav-container-bg:         transparent !default;
+$tabs-nav-container-shadow:     none !default;
+$tabs-nav-container-margin:     0 !default;
+$tabs-nav-container-border:     1px solid $gray-300 !default;
+
+$tabs-nav-vertical-margin:      0 0 0 map-get($map: $spacers, $key: 4);
+
+$tabs-pane-container-padding:   1.25rem !default;
+
+$tabs-tab-padding-y: 0.5rem !default;
+$tabs-tab-padding-x: 1.25rem !default;
+$tabs-tab-color: $gray-700 !default;
+$tabs-tab-bg: transparent !default;
+$tabs-tab-border-color: transparent !default;
+$tabs-tab-border-width: 0 0 2px 0 !default;
+$tabs-tab-border-radius: 0 !default;
+
+$tabs-tab-transition: border-color 0.3s !default;
+
+$tabs-tab-hover-color: $primary !default;
+$tabs-tab-hover-bg: transparent !default;
+$tabs-tab-hover-border-color: transparent !default;
+
+$tabs-tab-active-color: $primary !default;
+$tabs-tab-active-bg: transparent !default;
+$tabs-tab-active-border-color: $primary !default;
+
+$tabs-tab-disabled-bg: transparent !default;
+$tabs-tab-disabled-border-color: transparent !default;
+$tabs-tab-disabled-color: $gray-500 !default;
+
+// Vertical tabs
+
+$tabs-tab-vertical-margin: 0 0 map-get($spacers, 1) !default;
+$tabs-tab-vertical-border-width: 1px !default;
+$tabs-tab-vertical-border-color: transparent !default;
+$tabs-tab-vertical-border-radius: $btn-border-radius !default;
+
+$tabs-tab-vertical-transition: none !default;
+
+$tabs-tab-vertical-hover-border-width: $tabs-tab-vertical-border-width !default;
+$tabs-tab-vertical-hover-border-color: transparent !default;
+
+$tabs-tab-vertical-active-border-width: $tabs-tab-vertical-border-width !default;
+$tabs-tab-vertical-active-border-color: $primary !default;
+
+$tabs-tab-vertical-disabled-border-width: $tabs-tab-vertical-border-width !default;
+$tabs-tab-vertical-disabled-border-color: $tabs-tab-disabled-color !default;
+
+
 // Navbar
 
 $navbar-padding-y:                  ($spacer / 2) !default;
@@ -677,7 +736,7 @@ $navbar-nav-link-padding-x:         .5rem !default;
 
 $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
-$nav-link-height:                   ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;
+$nav-link-height:                   ($font-size-base * $line-height-base + $nav-item-padding-y * 2) !default;
 $navbar-brand-height:               $navbar-brand-font-size * $line-height-base !default;
 $navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) / 2 !default;
 

--- a/styles/theme/_variables.scss
+++ b/styles/theme/_variables.scss
@@ -413,15 +413,17 @@ $btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($b
 // TODO: this shouldn't be needed anymore since we're not doing custom focus styles
 $btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
 
-$btn-bg-hover-darken:         7.5%;
-$btn-bg-active-darken:        10%;
+$btn-bg-hover-darken:         7.5% !default;
+$btn-bg-active-darken:        10% !default;
 
 // Disabled buttons
 $btn-link-disabled-color:     $gray-600 !default;
 $btn-disabled-opacity:        .65 !default;
+$btn-disabled-border-width: $btn-border-width !default;
 
 // The following variables are undefined and can be set by an application to
-// create consistent disabled button styles
+// create a single consistent disabled button style instead of the reduced
+// opacity theme color default style
 // $btn-disabled-bg
 // $btn-disabled-border
 // $btn-disabled-color


### PR DESCRIPTION
## Componentry Button refactors

_Large scale refactor of library Button component usage_

#### Changes

- `Nav` component refactored to more clearly use `nav-item` and `nav-item-action` classes.
- Added library `.disabled` styles
- Rewrote the Tabs component styles
- REMOVED `:disabled` handlers - use `.disabled` to work with buttons and anchors
- Disambiguated usage of `btn-anchor`, `btn-close` and `btn-link`
- Added `$dropdown-item-line-height` variable
