### PR TITLE
feat: add btn-bg-states override mechanism

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 styles/theme/_variables.scss
+styles/theme/_button.scss
 demo/styles/theme.scss

--- a/demo/styles/application/app.scss
+++ b/demo/styles/application/app.scss
@@ -5,7 +5,7 @@
 // element theming for buttons && headers (Note that these vars correspond to
 // the theme which sets the var to the SASS variable)
 :root {
-  --btn-disabled-color: #89a19d;
+  --btn-disabled-border-color: #{$gray-600};
   --headings-color: #{$gray-800};
 }
 

--- a/demo/styles/theme.scss
+++ b/demo/styles/theme.scss
@@ -77,11 +77,14 @@ $headings-color:          var(--headings-color);
 // Buttons
 $btn-font-weight:         300; // The white Libre Franklin font looks nice at a lighter weight
 
+$btn-bg-states: (
+  disabled: transparent,
+);
+
 // Demo using a single diabled style for all button colors
-$btn-disabled-bg:         transparent;
-$btn-disabled-border:     #e1e7e6;
-$btn-disabled-color:      var(--btn-disabled-color);
-$btn-disabled-opacity:    1; // Overrides default behavior of reducing opacity
+$btn-disabled-opacity:           1; // Overrides default behavior of reducing opacity
+$btn-disabled-border-color:      var(--btn-disabled-border-color);
+$btn-disabled-color:             $gray-700;
 
 // Tooltips
 

--- a/src/Button/button.scss
+++ b/src/Button/button.scss
@@ -1,5 +1,11 @@
 /* componentry/src/Button/button */
 
+/*
+ * Button customizations to document:
+ * - Disabled state overrides
+ * - Btn states override
+ */
+
 //
 // Base styles
 //
@@ -38,34 +44,45 @@
 
 @each $color, $value in $theme-colors {
   .btn-#{$color} {
+    @if map-get($btn-bg-states, $color) {
+      background: map-get($btn-bg-states, $color);
+    } @else {
+      @include gradient-bg($value);
+    }
     border-color: $value;
     color: color-yiq($value);
-    @include gradient-bg($value);
 
     &:hover {
+      @if map-get($btn-bg-states, #{$color}-hover) {
+        background: map-get($btn-bg-states, #{$color}-hover);
+      } @else {
+        @include gradient-bg(darken($value, $btn-bg-hover-darken));
+      }
       border-color: darken($value, 10%);
       color: color-yiq($value);
-      @include gradient-bg(darken($value, $btn-bg-hover-darken));
     }
 
     &:active,
     &.active {
+      @if map-get($btn-bg-states, #{$color}-active) {
+        background: map-get($btn-bg-states, #{$color}-active);
+      } @else {
+        @include gradient-bg(darken($value, $btn-bg-active-darken));
+      }
       border-color: darken($value, 12.5%);
       color: color-yiq($value);
-      @include gradient-bg(darken($value, $btn-bg-active-darken));
     }
 
     // Disabled buttons can be styled to a consistent appearance with optional
     // disabled theme vars, otherwise reset to default appearance with an
     // opacity change to indicate disabled state
     &.disabled {
-      border-width: $btn-disabled-border-width;
-
-      @if variable-exists(btn-disabled-bg) {
-        @include gradient-bg($btn-disabled-bg);
+      @if map-get($btn-bg-states, disabled) {
+        background: map-get($btn-bg-states, disabled);
       } @else {
         @include gradient-bg($value);
       }
+      border-width: $btn-disabled-border-width;
 
       @if variable-exists(btn-disabled-border-color) {
         border-color: $btn-disabled-border-color;

--- a/styles/theme/_button.scss
+++ b/styles/theme/_button.scss
@@ -1,0 +1,52 @@
+// Buttons
+//
+// For each of Componentry's buttons, define text, background, and border color.
+
+$btn-padding-y:               $input-btn-padding-y !default;
+$btn-padding-x:               $input-btn-padding-x !default;
+$btn-line-height:             $input-btn-line-height !default;
+$btn-border-radius:           $border-radius !default;
+$btn-letter-spacing:          0px !default;
+
+$btn-padding-y-sm:            $input-btn-padding-y-sm !default;
+$btn-padding-x-sm:            $input-btn-padding-x-sm !default;
+$btn-line-height-sm:          $input-btn-line-height-sm !default;
+$btn-border-radius-sm:        $border-radius-sm !default;
+$btn-letter-spacing-sm:       $btn-letter-spacing !default;
+
+$btn-padding-y-lg:            $input-btn-padding-y-lg !default;
+$btn-padding-x-lg:            $input-btn-padding-x-lg !default;
+$btn-line-height-lg:          $input-btn-line-height-lg !default;
+$btn-border-radius-lg:        $border-radius-lg !default;
+$btn-letter-spacing-lg:       $btn-letter-spacing !default;
+
+$btn-border-width:            $input-btn-border-width !default;
+$btn-text-transform:          none !default;
+$btn-font-weight:             $font-weight-normal !default;
+
+$btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
+// TODO: this shouldn't be needed anymore since we're not doing custom focus styles
+$btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
+
+$btn-bg-hover-darken:         7.5% !default;
+$btn-bg-active-darken:        10% !default;
+
+// The btn-states is a backdoor to set specific color values for button states
+$btn-bg-states:                  () !default;
+
+// Disabled buttons
+$btn-link-disabled-color:     $gray-600 !default;
+$btn-disabled-opacity:        .65 !default;
+$btn-disabled-border-width:   $btn-border-width !default;
+
+// The following variables are undefined and can be set by an application to
+// create a single consistent disabled button style instead of the reduced
+// opacity theme color default style
+// $btn-disabled-border-color
+// $btn-disabled-color
+
+// Sets margin between stacked block buttons
+$btn-block-spacing-y:         .5rem !default;
+
+// Customize button transition styles
+$btn-transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;

--- a/styles/theme/_variables.scss
+++ b/styles/theme/_variables.scss
@@ -383,59 +383,8 @@ $input-btn-border-width:      $border-width !default;
 
 
 // Buttons
-//
-// For each of Componentry's buttons, define text, background, and border color.
 
-$btn-padding-y:               $input-btn-padding-y !default;
-$btn-padding-x:               $input-btn-padding-x !default;
-$btn-line-height:             $input-btn-line-height !default;
-
-$btn-padding-y-sm:            $input-btn-padding-y-sm !default;
-$btn-padding-x-sm:            $input-btn-padding-x-sm !default;
-$btn-line-height-sm:          $input-btn-line-height-sm !default;
-
-$btn-padding-y-lg:            $input-btn-padding-y-lg !default;
-$btn-padding-x-lg:            $input-btn-padding-x-lg !default;
-$btn-line-height-lg:          $input-btn-line-height-lg !default;
-
-$btn-border-radius:           $border-radius !default;
-$btn-border-radius-lg:        $border-radius-lg !default;
-$btn-border-radius-sm:        $border-radius-sm !default;
-
-$btn-border-width:            $input-btn-border-width !default;
-
-$btn-letter-spacing:          0px !default;
-$btn-letter-spacing-sm:       $btn-letter-spacing !default;
-$btn-letter-spacing-lg:       $btn-letter-spacing !default;
-
-$btn-text-transform:          none !default;
-$btn-font-weight:             $font-weight-normal !default;
-
-$btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
-// TODO: this shouldn't be needed anymore since we're not doing custom focus styles
-$btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
-
-$btn-bg-hover-darken:         7.5% !default;
-$btn-bg-active-darken:        10% !default;
-
-// Disabled buttons
-$btn-link-disabled-color:     $gray-600 !default;
-$btn-disabled-opacity:        .65 !default;
-$btn-disabled-border-width:   $btn-border-width !default;
-
-// The following variables are undefined and can be set by an application to
-// create a single consistent disabled button style instead of the reduced
-// opacity theme color default style
-// $btn-disabled-bg
-// $btn-disabled-border-color
-// $btn-disabled-color
-
-// Sets margin between stacked block buttons
-$btn-block-spacing-y:         .5rem !default;
-
-// Customize button transition styles
-$btn-transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
-
+@import './button';
 
 // Forms
 


### PR DESCRIPTION
Adds a new feature: `$btn-bg-states` which is a map that allows users to override specific button backgrounds for a specific state. This is especially useful if you don't want the exact same color darkening for each theme color.
