### PR TITLE
Feature/maps overrides

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
 styles/theme/_variables.scss
 styles/theme/_button.scss
 styles/theme/_input.scss
+
+src/Button/button.scss
+
 demo/styles/theme.scss

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 styles/theme/_variables.scss
+styles/theme/_alert.scss
 styles/theme/_button.scss
 styles/theme/_input.scss
 

--- a/demo/components/ComponentsScreen/Screens/Alerts.md
+++ b/demo/components/ComponentsScreen/Screens/Alerts.md
@@ -42,6 +42,8 @@ component to automatically create an uncontrolled Alert.
     `<Alert color="${color}"${outline ? ' outline' : ''}>
   <h4 className="alert-heading">Well done!</h4>
   <p className="mb-0">You successfully read this important alert message.</p>
+  <hr />
+  <Anchor href="#" className="alert-link">Go home</Anchor>
 </Alert>`
   )}
   renderComponent={({ color, dismissible, outline }) => (
@@ -50,6 +52,8 @@ component to automatically create an uncontrolled Alert.
         <Alert color={color} dismissible={dismissible} outline={outline}>
           <h4 className="alert-heading">Well done!</h4>
           <p className="mb-0">You successfully read this important alert message.</p>
+          <hr />
+          <Anchor href="#" className="alert-link">Go home</Anchor>
         </Alert>
       </Active>
     </div>

--- a/demo/styles/theme.scss
+++ b/demo/styles/theme.scss
@@ -74,17 +74,14 @@ $h4-font-size:            $font-size-base * 1.2;
 $headings-font-weight:    300;
 $headings-color:          var(--headings-color);
 
+// --- Alerts
+
+$alert-color-level:       2;
+
+
 // Buttons
+
 $btn-font-weight:         300; // The white Libre Franklin font looks nice at a lighter weight
-
-$btn-bg-states: (
-  disabled: transparent,
-);
-
-// Demo using a single diabled style for all button colors
-$btn-disabled-opacity:           1; // Overrides default behavior of reducing opacity
-$btn-disabled-border-color:      var(--btn-disabled-border-color);
-$btn-disabled-color:             $gray-700;
 
 // Tooltips
 

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -77,7 +77,9 @@ const Alert = ({
         <div className="alert-content">{children}</div>
 
         {/* Render a close button or null depending on configs */}
-        {dismissible && <Close onClick={deactivate} className={`text-${color}`} />}
+        {dismissible && (
+          <Close onClick={deactivate} className={`alert-close text-${color}`} />
+        )}
       </Fragment>
     ),
     ...cleanActive(rest),

--- a/src/Alert/alert.scss
+++ b/src/Alert/alert.scss
@@ -1,5 +1,19 @@
 /* componentry/src/Alert/alert */
 
+$alert-defaults: ();
+@each $color, $value in $theme-colors {
+  $alert-defaults: map-merge(
+    $alert-defaults,
+    (
+      #{$color}-bg: #{gradient-background(theme-color-level($color, $alert-bg-level))},
+      #{$color}-border-color: #{theme-color-level($color, $alert-border-level)},
+      #{$color}-color: #{theme-color-level($color, $alert-color-level)}
+    )
+  );
+}
+
+$alert-states-map: map-merge($alert-defaults, $alert-states);
+
 // Make the alert container a flex container by default with space-between to align
 // close button to right side
 .alert {
@@ -13,6 +27,45 @@
   @include border-radius($alert-border-radius);
 }
 
+// Alternate styles
+//
+// Generate contextual modifier classes for colorizing the alert.
+
+@each $color, $value in $theme-colors {
+  .alert-#{$color} {
+    background: map-get($alert-states-map, #{$color}-bg);
+    border-color: map-get($alert-states-map, #{$color}-border-color);
+    color: map-get($alert-states-map, #{$color}-color);
+
+    hr {
+      border-top-color: darken(theme-color-level($color, $alert-border-level), 5%);
+    }
+
+    .alert-link {
+      color: darken(theme-color-level($color, $alert-color-level), 10%);
+    }
+  }
+
+  // Outline alerts have a transparent background with a bright left side border
+  .alert-#{$color}.alert-outline {
+    background-color: transparent;
+    border-color: $border-color;
+    border-left: 5px solid $value;
+  }
+}
+
+//
+// Alert elements
+//
+
+.alert-content {
+  flex-grow: 1;
+}
+
+.alert-close {
+  margin-left: $alert-close-margin-left;
+}
+
 // Headings for larger alerts
 .alert-heading {
   // Specified to prevent conflicts of changing $headings-color
@@ -22,44 +75,4 @@
 // Provide class for links that match alerts
 .alert-link {
   font-weight: $alert-link-font-weight;
-}
-
-// Alternate styles
-//
-// Generate contextual modifier classes for colorizing the alert.
-
-@mixin alert-variant($background, $border, $color) {
-  color: $color;
-  @include gradient-bg($background);
-  border-color: $border;
-
-  hr {
-    border-top-color: darken($border, 5%);
-  }
-
-  .alert-link {
-    color: darken($color, 10%);
-  }
-}
-
-@each $color, $value in $theme-colors {
-  .alert-#{$color} {
-    @include alert-variant(
-      theme-color-level($color, $alert-bg-level),
-      theme-color-level($color, $alert-border-level),
-      theme-color-level($color, $alert-color-level)
-    );
-  }
-}
-
-// Outline styles
-//
-// Outline alerts have a transparent background with a bright left side border
-
-@each $color, $value in $theme-colors {
-  .alert-#{$color}.alert-outline {
-    background-color: transparent;
-    border-color: $border-color;
-    border-left: 5px solid $value;
-  }
 }

--- a/src/Button/button.scss
+++ b/src/Button/button.scss
@@ -6,6 +6,32 @@
  * - Btn states override
  */
 
+$btn-defaults: ();
+@each $color, $value in $theme-colors {
+  $btn-defaults: map-merge(
+    $btn-defaults,
+    (
+      // --- Background color
+      #{$color}-bg: #{gradient-background($value)},
+      #{$color}-hover-bg: #{gradient-background(darken($value, 7.5%))},
+      #{$color}-active-bg: #{gradient-background(darken($value, 10%))},
+      #{$color}-disabled-bg: #{gradient-background($value)},
+      // --- Border color
+      #{$color}-border-color: #{$value},
+      #{$color}-hover-border-color: #{darken($value, 10%)},
+      #{$color}-active-border-color: #{darken($value, 12.5%)},
+      #{$color}-disabled-border-color: #{$value},
+      // --- Color
+      #{$color}-color: #{color-yiq($value)},
+      #{$color}-hover-color: #{color-yiq($value)},
+      #{$color}-active-color: #{color-yiq($value)},
+      #{$color}-disabled-color: #{color-yiq($value)}
+    )
+  );
+}
+
+$btn-states-map: map-merge($btn-defaults, $btn-states);
+
 //
 // Base styles
 //
@@ -34,6 +60,7 @@
   // Default disabled styles remove pointer and adjust opacity to indicate
   // button is disabled
   &.disabled {
+    border-width: $btn-disabled-border-width;
     opacity: $btn-disabled-opacity;
   }
 }
@@ -44,57 +71,27 @@
 
 @each $color, $value in $theme-colors {
   .btn-#{$color} {
-    @if map-get($btn-bg-states, $color) {
-      background: map-get($btn-bg-states, $color);
-    } @else {
-      @include gradient-bg($value);
-    }
-    border-color: $value;
-    color: color-yiq($value);
+    background: map-get($btn-states-map, #{$color}-bg);
+    border-color: map-get($btn-states-map, #{$color}-border-color);
+    color: map-get($btn-states-map, #{$color}-color);
 
     &:hover {
-      @if map-get($btn-bg-states, #{$color}-hover) {
-        background: map-get($btn-bg-states, #{$color}-hover);
-      } @else {
-        @include gradient-bg(darken($value, $btn-bg-hover-darken));
-      }
-      border-color: darken($value, 10%);
-      color: color-yiq($value);
+      background: map-get($btn-states-map, #{$color}-hover-bg);
+      border-color: map-get($btn-states-map, #{$color}-hover-border-color);
+      color: map-get($btn-states-map, #{$color}-hover-color);
     }
 
     &:active,
     &.active {
-      @if map-get($btn-bg-states, #{$color}-active) {
-        background: map-get($btn-bg-states, #{$color}-active);
-      } @else {
-        @include gradient-bg(darken($value, $btn-bg-active-darken));
-      }
-      border-color: darken($value, 12.5%);
-      color: color-yiq($value);
+      background: map-get($btn-states-map, #{$color}-active-bg);
+      border-color: map-get($btn-states-map, #{$color}-active-border-color);
+      color: map-get($btn-states-map, #{$color}-active-color);
     }
 
-    // Disabled buttons can be styled to a consistent appearance with optional
-    // disabled theme vars, otherwise reset to default appearance with an
-    // opacity change to indicate disabled state
     &.disabled {
-      @if map-get($btn-bg-states, disabled) {
-        background: map-get($btn-bg-states, disabled);
-      } @else {
-        @include gradient-bg($value);
-      }
-      border-width: $btn-disabled-border-width;
-
-      @if variable-exists(btn-disabled-border-color) {
-        border-color: $btn-disabled-border-color;
-      } @else {
-        border-color: $value;
-      }
-
-      @if variable-exists(btn-disabled-color) {
-        color: $btn-disabled-color;
-      } @else {
-        color: color-yiq($value);
-      }
+      background: map-get($btn-states-map, #{$color}-disabled-bg);
+      border-color: map-get($btn-states-map, #{$color}-disabled-border-color);
+      color: map-get($btn-states-map, #{$color}-disabled-color);
     }
   }
 }

--- a/styles/theme/_alert.scss
+++ b/styles/theme/_alert.scss
@@ -1,0 +1,15 @@
+$alert-padding-y:                   .75rem !default;
+$alert-padding-x:                   1.25rem !default;
+$alert-margin-bottom:               1rem !default;
+$alert-border-radius:               $border-radius !default;
+$alert-link-font-weight:            $font-weight-bold !default;
+$alert-border-width:                $border-width !default;
+
+$alert-bg-level:                    -10 !default;
+$alert-border-level:                -9 !default;
+$alert-color-level:                 6 !default;
+
+$alert-close-margin-left:           0.5rem !default;
+
+// The alert-states is a backdoor to set specific color values for alert states
+$alert-states:                      () !default;

--- a/styles/theme/_button.scss
+++ b/styles/theme/_button.scss
@@ -7,6 +7,10 @@ $btn-padding-x:               $input-btn-padding-x !default;
 $btn-line-height:             $input-btn-line-height !default;
 $btn-border-radius:           $border-radius !default;
 $btn-letter-spacing:          0px !default;
+$btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
+$btn-border-width:            $input-btn-border-width !default;
+$btn-text-transform:          none !default;
+$btn-font-weight:             $font-weight-normal !default;
 
 $btn-padding-y-sm:            $input-btn-padding-y-sm !default;
 $btn-padding-x-sm:            $input-btn-padding-x-sm !default;
@@ -20,33 +24,19 @@ $btn-line-height-lg:          $input-btn-line-height-lg !default;
 $btn-border-radius-lg:        $border-radius-lg !default;
 $btn-letter-spacing-lg:       $btn-letter-spacing !default;
 
-$btn-border-width:            $input-btn-border-width !default;
-$btn-text-transform:          none !default;
-$btn-font-weight:             $font-weight-normal !default;
-
-$btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
-// TODO: this shouldn't be needed anymore since we're not doing custom focus styles
-$btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
-
-$btn-bg-hover-darken:         7.5% !default;
-$btn-bg-active-darken:        10% !default;
-
-// The btn-states is a backdoor to set specific color values for button states
-$btn-bg-states:                  () !default;
-
-// Disabled buttons
-$btn-link-disabled-color:     $gray-600 !default;
 $btn-disabled-opacity:        .65 !default;
 $btn-disabled-border-width:   $btn-border-width !default;
 
-// The following variables are undefined and can be set by an application to
-// create a single consistent disabled button style instead of the reduced
-// opacity theme color default style
-// $btn-disabled-border-color
-// $btn-disabled-color
+$btn-link-disabled-color:     $text-muted !default;
+
+// The btn-states is a backdoor to set specific color values for button states
+$btn-states:                  () !default;
 
 // Sets margin between stacked block buttons
 $btn-block-spacing-y:         .5rem !default;
 
 // Customize button transition styles
 $btn-transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
+
+// TODO: this shouldn't be needed anymore since we're not doing custom focus styles
+$btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;

--- a/styles/theme/_functions.scss
+++ b/styles/theme/_functions.scss
@@ -88,3 +88,14 @@
 
   @return mix($color-base, $color, $level * $theme-color-interval);
 }
+
+/**
+ * Returns a gradient background color when gradients are enabled for theme
+ */
+@function gradient-background($color) {
+  @if $enable-gradients {
+    @return $color linear-gradient(180deg, mix($body-bg, $color, 15%), $color) repeat-x;
+  } @else {
+    @return $color;
+  }
+}

--- a/styles/theme/_mixins.scss
+++ b/styles/theme/_mixins.scss
@@ -183,7 +183,8 @@
   }
 }
 
-// TODO make atomic class
+// DEPRECATED
+// Use the gradient-background function
 @mixin gradient-bg($color) {
   @if $enable-gradients {
     background: $color

--- a/styles/theme/_variables.scss
+++ b/styles/theme/_variables.scss
@@ -381,6 +381,9 @@ $input-btn-line-height-lg:    $line-height-lg !default;
 
 $input-btn-border-width:      $border-width !default;
 
+// Alerts
+
+@import 'alert';
 
 // Buttons
 
@@ -837,20 +840,6 @@ $modal-sm:                          300px !default;
 $modal-transition:                  transform .3s ease-out !default;
 
 
-// Alerts
-//
-// Define alert colors, border radius, and padding.
-
-$alert-padding-y:                   .75rem !default;
-$alert-padding-x:                   1.25rem !default;
-$alert-margin-bottom:               1rem !default;
-$alert-border-radius:               $border-radius !default;
-$alert-link-font-weight:            $font-weight-bold !default;
-$alert-border-width:                $border-width !default;
-
-$alert-bg-level:                    -10 !default;
-$alert-border-level:                -9 !default;
-$alert-color-level:                 6 !default;
 
 
 // Progress bars


### PR DESCRIPTION
Improves the override mechanism for adjusting specific theme values by generating maps of the values used and then merging them with a user defined map. This allows overriding values at a granular level.

BREAKING CHANGE: This changes the disabled props adjustments for buttons, attempting to set a single disabled style must now be done by theme color.