### PR TITLE
New: Scope anchor and header styles to className only ✨

### DIFF
--- a/src/Anchor/anchor.scss
+++ b/src/Anchor/anchor.scss
@@ -5,7 +5,6 @@
 // that look exactly like links for in application triggers, `anc`
 // creates a button styled exactly like an anchor. This should be used for any
 // application actions that are not route navigations.
-a,
 .a {
   -webkit-appearance: none !important; // Remove Chrome native button styling
   display: inline-block;

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -2,5 +2,6 @@ import elem from '../elem-factory'
 import { useTheme } from '../Theme/Theme'
 
 export default function Header(props) {
-  return elem({ as: 'h1', ...useTheme('Header'), ...props })
+  const merged = { as: 'h1', ...useTheme('Header'), ...props }
+  return elem({ componentClassNames: merged.as, ...merged })
 }

--- a/src/Header/header.scss
+++ b/src/Header/header.scss
@@ -22,7 +22,6 @@ $heading-weights: (
 // makes debugging styles much cleaner, and more closely aligns with the goal of
 // mapping classes to usage 1:1.
 @each $heading, $heading-font-size in $heading-sizes {
-  #{$heading},
   .#{$heading} {
     margin-top: 0;
     margin-bottom: $headings-margin-bottom;

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -1,6 +1,11 @@
 import elem from '../elem-factory'
 import { useTheme } from '../Theme/Theme'
 
+/**
+ * Text component
+ * TODO: use `span` prop to render a span?
+ */
 export default function Text(props) {
-  return elem({ as: 'p', ...useTheme('Text'), ...props })
+  const merged = { as: 'p', ...useTheme('Text'), ...props }
+  return elem({ componentClassNames: merged.as, ...merged })
 }

--- a/src/Text/text.scss
+++ b/src/Text/text.scss
@@ -1,1 +1,6 @@
 /* componentry/src/Text/text */
+
+.p {
+  margin-top: 0;
+  margin-bottom: $paragraph-margin-bottom;
+}

--- a/styles/_reboot.scss
+++ b/styles/_reboot.scss
@@ -87,12 +87,6 @@ hr:not([size]) {
   }
 }
 
-// Set paragraphs to have no margin-top and `em` margin bottom
-p {
-  margin-top: 0;
-  margin-bottom: $paragraph-margin-bottom;
-}
-
 // Abbreviations
 //
 // 1. Duplicate behavior to the data-* attribute for our tooltip plugin


### PR DESCRIPTION
Follows the library convention of using utility class names to apply styles whenever possible