### PR TITLE
New: Library Item components standardization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "componentry",
-  "version": "3.0.0-rc.4",
+  "version": "3.0.0-rc.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Active/__snapshots__/Active.spec.js.snap
+++ b/src/Active/__snapshots__/Active.spec.js.snap
@@ -7,7 +7,7 @@ exports[`<Active /> snapshots renders correctly 1`] = `
 >
   <button
     aria-controls="guid"
-    class="active-trigger a"
+    class="active-trigger"
     type="button"
   >
     Trigger

--- a/src/Anchor/Anchor.js
+++ b/src/Anchor/Anchor.js
@@ -6,10 +6,14 @@ import { useTheme } from '../Theme/Theme'
  * [Anchor component 📝](https://componentry.design/components/anchor)
  */
 export default function Anchor(props) {
-  const merged = { as: 'a', variant: 'a', ...useTheme('Anchor'), ...props }
+  const { variant = 'a', ...merged } = {
+    ...useTheme('Anchor'),
+    ...props,
+  }
 
   return elem({
-    elemClassName: actionClasses(merged),
+    as: 'a',
+    elemClassName: actionClasses(variant, merged),
     ...merged,
   })
 }

--- a/src/Anchor/anchor.scss
+++ b/src/Anchor/anchor.scss
@@ -6,30 +6,9 @@
 // creates a button styled exactly like an anchor. This should be used for any
 // application actions that are not route navigations.
 .a {
-  -webkit-appearance: none !important; // Remove Chrome native button styling
-  display: inline-block;
-  padding: 0;
-  background-color: transparent;
-  cursor: pointer;
-
-  // Set anchor font styles
   color: typography-color(anchor);
-  font-family: $font-family-sans-serif;
-  font-size: $font-size-base;
-  font-weight: $font-weight-normal;
-  line-height: $line-height-base;
-  letter-spacing: 0;
-  text-transform: none;
-
-  user-select: auto;
-  vertical-align: baseline;
-  white-space: normal;
-
-  border: none;
-  border-radius: 0;
-
   text-decoration: $anchor-decoration;
-  -webkit-text-decoration-skip: objects; // Remove gaps in links underline in iOS 8+ and Safari 8+.
+  background-color: transparent;
 
   &:hover {
     color: $anchor-hover-color;
@@ -41,19 +20,14 @@
     text-decoration: $anchor-active-decoration;
   }
 
-  // When no href is passed the Anchor component will include disabled, which
-  // we use to remove the stylesof the anchor
-  // See https://github.com/twbs/bootstrap/issues/19402
   &.disabled {
     color: $anchor-disabled-color;
     text-decoration: $anchor-disabled-decoration;
   }
 }
 
-@if ($enable-dom-styles) {
-  a {
-    @extend .a;
-  }
+button.a {
+  @include reset-button;
 }
 
 // Custom color style is needed to include :hover, and :focus styles

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -6,16 +6,15 @@ import { useTheme } from '../Theme/Theme'
  * [Button component 📝](https://componentry.design/components/button)
  */
 export default function Button(props) {
-  const merged = {
-    as: 'button',
-    type: 'button',
-    variant: 'btn',
+  const { as = 'button', type = 'button', variant = 'btn', ...merged } = {
     ...useTheme('Button'),
     ...props,
   }
 
   return elem({
-    elemClassName: actionClasses(merged),
+    as,
+    type,
+    elemClassName: actionClasses(variant, merged),
     ...merged,
   })
 }

--- a/src/Button/Button.stories.mdx
+++ b/src/Button/Button.stories.mdx
@@ -84,8 +84,8 @@ Create a button with anchor styles by passing `variant="a"` to a Button:
 
 <p>
   Always use a button or{' '}
-  <Button variant="a" onClick={action('anchor variant click')} color='primary'>
-    anchor
+  <Button variant="a" onClick={action('anchor variant click')}>
+    anchor 
   </Button>{' '}
   for creating interaction targets 👍
 </p>

--- a/src/Button/button.scss
+++ b/src/Button/button.scss
@@ -31,7 +31,6 @@ $btn-states-map: map-merge($btn-defaults, $btn-states);
 
 .btn {
   -webkit-appearance: button;
-  cursor: pointer;
   border: $btn-border-width solid transparent;
   @include border-radius($btn-border-radius);
   display: inline-block;

--- a/src/Close/close.scss
+++ b/src/Close/close.scss
@@ -22,7 +22,6 @@
   letter-spacing: 0;
   text-transform: none;
 
-  cursor: pointer;
   user-select: auto;
   vertical-align: baseline;
   white-space: normal;

--- a/src/Drawer/__snapshots__/Drawer.spec.js.snap
+++ b/src/Drawer/__snapshots__/Drawer.spec.js.snap
@@ -8,7 +8,7 @@ exports[`<Drawer /> snapshots renders correctly 1`] = `
   <button
     aria-controls="guid"
     aria-expanded="false"
-    class="drawer-trigger a"
+    class="drawer-trigger"
     type="button"
   >
     Trigger

--- a/src/Drawer/drawer.scss
+++ b/src/Drawer/drawer.scss
@@ -1,10 +1,6 @@
 /* componentry/src/Drawer/drawer */
 
 .drawer-trigger {
-  // Bs doesn't have real drawers, the 'Collapse' styles can be used to create
-  // them, but b/c they don't include any structural styles they are not
-  // convenient for creating standard drawers with minimal markup. Add display
-  // for standard drawers to prevent drawer content from starting at drawer
-  // button boundary
+  @include active-trigger-element;
   display: block;
 }

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -23,8 +23,8 @@ Dropdown.Content = activeContent('dropdown', {
  * [Dropdown item component 📝](https://componentry.design/components/dropdown)
  */
 Dropdown.Item = activeTrigger('dropdown', {
-  baseClass: 'dropdown-item',
   displayName: 'DropdownItem',
+  variant: 'dropdown-item',
 })
 
 /**

--- a/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -8,7 +8,7 @@ exports[`<Dropdown /> snapshots renders correctly 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="dropdown-trigger a"
+    class="dropdown-trigger"
     id="guid"
     type="button"
   >
@@ -20,13 +20,13 @@ exports[`<Dropdown /> snapshots renders correctly 1`] = `
     class="dropdown-content"
   >
     <button
-      class="dropdown-item a"
+      class="dropdown-item"
       type="button"
     >
       Item 1
     </button>
     <button
-      class="dropdown-item a"
+      class="dropdown-item"
       type="button"
     >
       Item 2

--- a/src/Dropdown/dropdown.scss
+++ b/src/Dropdown/dropdown.scss
@@ -18,6 +18,8 @@
 //
 
 .dropdown-trigger {
+  @include active-trigger-element;
+
   font-size: $dropdown-font-size;
   font-weight: $dropdown-font-weight;
 }
@@ -121,7 +123,7 @@
   padding: $dropdown-item-padding-y $dropdown-item-padding-x;
   // Ensure that buttons and anchors inherit dropdown container font styles
   font-size: inherit;
-  font-weight: inherit;
+  font-weight: $font-weight-normal;
   color: $dropdown-action-item-color;
   line-height: $dropdown-item-line-height;
   white-space: nowrap; // prevent links from randomly breaking onto new lines

--- a/src/Heading/Heading.js
+++ b/src/Heading/Heading.js
@@ -18,13 +18,13 @@ const asMap = {
  * [Heading component 📝](https://componentry.design/components/heading)
  */
 export default function Heading(props) {
-  const { as, display, variant, ...rest } = {
-    variant: 'heading-1',
+  const { variant = 'heading-1', ...rest } = {
     ...useTheme('Heading'),
     ...props,
   }
+
   return elem({
-    as: as || asMap[variant],
+    as: asMap[variant],
     elemClassName: variant,
     ...rest,
   })

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -6,13 +6,13 @@ import { useTheme } from '../Theme/Theme'
  * [List component 📝](https://componentry.design/components/list)
  */
 export default function List(props) {
+  const { flush = false, ...rest } = { ...useTheme('List'), ...props }
+
   // Lists check first child (only first child!) to see if it has actions, and
   // if it does, it's not a `li` so we render a `ul`.
   const child = Children.toArray(props.children)[0]
   // We have to be careful of children like text nodes with this check
   const childProps = child && child.props ? child.props : {}
-
-  const { flush, ...rest } = { ...useTheme('List'), ...props }
 
   return elem({
     as: childProps.href || childProps.onClick ? 'div' : 'ul',
@@ -26,7 +26,7 @@ List.displayName = 'List'
  * [List item component 📝](https://componentry.design/components/list)
  */
 List.Item = function ListItem(props) {
-  const { active, color, ...rest } = { ...useTheme('ListItem'), ...props }
+  const { active = false, color = '', ...rest } = { ...useTheme('ListItem'), ...props }
   const { href, onClick } = rest
 
   return elem({

--- a/src/List/List.stories.mdx
+++ b/src/List/List.stories.mdx
@@ -6,46 +6,44 @@ import { colors } from '../storybook-resources'
 
 <Meta title='Components/List' component={List} />
 
-<DocsTitle title="List Groups" experimental/>
-
-<List>
-  <List.Item>Radical React</List.Item>
-  <List.Item>Component Library</List.Item>
-  <List.Item>Design System</List.Item>
-</List>
+<DocsTitle title="List Groups" />
 
 ## Unordered list
 
 <List>
+  <List.Item active>Radical React</List.Item>
   <List.Item>Radical React</List.Item>
   <List.Item>Component Library</List.Item>
   <List.Item>Design System</List.Item>
+  <List.Item disabled>Radical React</List.Item>
 </List>
 
 ## Anchor list
 
 <List>
+  <List.Item active href='#'>Radical React</List.Item>
   <List.Item href='#'>Radical React</List.Item>
   <List.Item href='#'>Component Library</List.Item>
   <List.Item href='#'>Design System</List.Item>
+  <List.Item disabled href='#'>Radical React</List.Item>
 </List>
 
 ## Button list
 
 <List>
+  <List.Item active onClick={action('item-click')}>Radical React</List.Item>
   <List.Item onClick={action('item-click')}>Radical React</List.Item>
   <List.Item onClick={action('item-click')}>Component Library</List.Item>
   <List.Item onClick={action('item-click')}>Design System</List.Item>
+  <List.Item disabled onClick={action('item-click')}>Radical React</List.Item>
 </List>
 
-## List items
+## Theme color items
 
 <List>
-  <List.Item active>Active list item</List.Item>
-  <List.Item disabled>Disabled list item</List.Item>
   {colors.map(color => (
     <List.Item color={color} key={color}>
-      {colors[color]} themed list item
+      {color} themed list item
     </List.Item>
   ))}
 </List>

--- a/src/List/list.scss
+++ b/src/List/list.scss
@@ -19,10 +19,13 @@
   position: relative;
   display: block;
   padding: $list-item-padding-y $list-item-padding-x;
-  // Place the border on the list items and negative margin up for better styling
-  margin-bottom: -$list-border-width;
   background-color: $list-bg;
   border: $list-border-width solid $list-border-color;
+
+  // For subsequent list item's remove the border top so we don't double up
+  & + .list-item {
+    border-top: 0;
+  }
 
   &:first-child {
     @include border-top-radius($list-border-radius);
@@ -33,14 +36,9 @@
     @include border-bottom-radius($list-border-radius);
   }
 
-  @include hover-focus {
-    z-index: 1; // Place hover/active items above their siblings for proper border styling
-    text-decoration: none;
-  }
-
   &.disabled {
-    color: $list-disabled-color;
-    background-color: $list-disabled-bg;
+    color: $list-disabled-item-color;
+    background-color: $list-disabled-item-bg;
   }
 }
 
@@ -52,23 +50,25 @@
 // selected items.
 
 .list-action-item {
-  @include reset-action-item;
-  width: 100%; // For `<button>`s (anchors become 100% by default though)
-  color: $list-action-color;
-  text-align: inherit; // For `<button>`s (anchors inherit)
+  color: $list-action-item-color;
+  font-size: inherit; // -> buttons
+  text-align: inherit; // -> buttons
+  text-decoration: none; // -> anchors
 
   // Hover state
-  @include hover-focus {
-    color: $list-action-hover-color;
+  &:hover,
+  &:focus {
+    z-index: 1; // Place hover/focus items above their siblings for proper border styling
+    color: $list-action-item-hover-color;
+    background-color: $list-action-item-hover-bg;
     text-decoration: none;
-    background-color: $list-hover-bg;
   }
 
   // Note that the active state is different from having the active class
   // (Class is persistent, state is for user interaction)
   &:active {
-    color: $list-action-active-color;
-    background-color: $list-action-active-bg;
+    color: $list-action-item-active-color;
+    background-color: $list-action-item-active-bg;
   }
 }
 
@@ -79,9 +79,9 @@
 // over :hover (Note this is valid for items and action items)
 .list-item.active {
   z-index: 2; // Place active items above their siblings for proper border styling
-  color: $list-active-color;
-  background-color: $list-active-bg;
-  border-color: $list-active-border-color;
+  color: $list-active-item-color;
+  background-color: $list-active-item-bg;
+  border-color: $list-active-item-border-color;
 }
 
 // --------------------------------------------------------
@@ -114,30 +114,25 @@
 
 // Add modifier classes to change text and background color on individual items.
 // (Organizationally, this must come after the `:hover` states)
-@mixin list-item-variant($state, $background, $color) {
-  .list-item-#{$state} {
+@each $color, $value in $theme-colors {
+  $background: theme-color-level($color, -9);
+  $foreground: theme-color-level($color, 6);
+
+  .list-item-#{$color} {
     color: $color;
     background-color: $background;
 
     &.list-action-item {
       @include hover-focus {
-        color: $color;
+        color: $foreground;
         background-color: darken($background, 5%);
       }
 
       &.active {
         color: theme-color(background);
-        background-color: $color;
-        border-color: $color;
+        background-color: $foreground;
+        border-color: $foreground;
       }
     }
   }
-}
-
-@each $color, $value in $theme-colors {
-  @include list-item-variant(
-    $color,
-    theme-color-level($color, -9),
-    theme-color-level($color, 6)
-  );
 }

--- a/src/Nav/Nav.js
+++ b/src/Nav/Nav.js
@@ -1,6 +1,6 @@
 import elem from '../elem-factory'
 import { useTheme } from '../Theme/Theme'
-import { navClasses } from '../utils/componentry'
+import { actionClasses, navClasses } from '../utils/componentry'
 
 /**
  * [Nav component 📝](https://componentry.design/components/nav)
@@ -8,7 +8,8 @@ import { navClasses } from '../utils/componentry'
 export default function Nav(props) {
   return elem({
     as: 'nav',
-    elemClassName: ['nav', navClasses(props)],
+    elemClassName: navClasses('nav', props),
+    role: 'navigation',
     ...useTheme('Nav'),
     ...props,
   })
@@ -19,21 +20,15 @@ Nav.displayName = 'Nav'
  * [Nav item component 📝](https://componentry.design/components/nav)
  */
 Nav.Item = function NavItem(props) {
-  const { active, ...rest } = { ...useTheme('NavItem'), ...props }
-  const { href, onClick } = rest
+  const { variant = 'nav-item', ...merged } = {
+    ...useTheme('NavItem'),
+    ...props,
+  }
 
   return elem({
-    /* eslint-disable no-nested-ternary */
-    as: href || onClick ? (href ? 'a' : 'button') : 'li',
-    elemClassName: [
-      'nav-item',
-      {
-        'nav-item-action': href || onClick,
-        active,
-        disabled: rest.disabled,
-      },
-    ],
-    ...rest,
+    as: 'a',
+    elemClassName: actionClasses(variant, merged),
+    ...merged,
   })
 }
 Nav.Item.displayName = 'NavItem'

--- a/src/Nav/Nav.stories.mdx
+++ b/src/Nav/Nav.stories.mdx
@@ -1,10 +1,11 @@
 import { boolean } from '@storybook/addon-knobs'
 
 import Nav from './Nav'
+import Anchor from '../Anchor/Anchor'
 
 <Meta title='Components/Nav' component={Nav} />
 
-<DocsTitle title="Navs" experimental/>
+<DocsTitle title="Navs"/>
 
 <div className='w-50'>
   <Nav
@@ -13,10 +14,10 @@ import Nav from './Nav'
     pills={boolean('pills', false)}
     vertical={boolean('vertical', false)}
   >
-    <Nav.Item href='#' active>
+    <Nav.Item active href='#' >
       Active
     </Nav.Item>
-    <Nav.Item href='#'>React</Nav.Item>
+    <Nav.Item href="#">React</Nav.Item>
     <Nav.Item href='#'>Redux</Nav.Item>
     <Nav.Item href='#' disabled>
       Styles

--- a/src/Nav/__snapshots__/Nav.spec.js.snap
+++ b/src/Nav/__snapshots__/Nav.spec.js.snap
@@ -3,27 +3,28 @@
 exports[`<Nav /> snapshots renders correctly 1`] = `
 <nav
   class="nav"
+  role="navigation"
 >
   <a
-    class="nav-item nav-item-action active"
+    class="nav-item active"
     href="#"
   >
     Active
   </a>
   <a
-    class="nav-item nav-item-action"
+    class="nav-item"
     href="#"
   >
     React
   </a>
   <a
-    class="nav-item nav-item-action"
+    class="nav-item"
     href="#"
   >
     Redux
   </a>
   <a
-    class="nav-item nav-item-action disabled"
+    class="nav-item disabled"
     disabled=""
     href="#"
   >

--- a/src/Nav/nav.scss
+++ b/src/Nav/nav.scss
@@ -1,14 +1,13 @@
 /* ~componentry/src/Nav/nav */
 
 // --------------------------------------------------------
-// Nav container (<nav> or <ul>)
+// Nav container <nav>
 
 .nav {
   display: flex;
   flex-wrap: wrap;
   padding-left: 0;
   margin-bottom: 0;
-  list-style: none;
 }
 
 // --------------------------------------------------------
@@ -33,7 +32,7 @@
 }
 
 // --------------------------------------------------------
-// Justified
+// Filled
 
 .nav-fill {
   .nav-item {
@@ -41,6 +40,9 @@
     text-align: center;
   }
 }
+
+// --------------------------------------------------------
+// Justified
 
 .nav-justified {
   .nav-item {
@@ -54,25 +56,5 @@
 // Nav items
 
 .nav-item {
-  -webkit-appearance: none;
-  border: none;
-  display: block;
   padding: $nav-item-padding-y $nav-item-padding-x;
-  background: transparent;
-}
-
-.nav-item-action {
-  color: $nav-item-action-color;
-  text-align: left; // reset button font
-
-  @include hover-focus {
-    color: $nav-item-action-hover-color;
-    text-decoration: $nav-item-action-hover-decoration;
-  }
-
-  // Disabled state lightens text
-  &.disabled {
-    color: $nav-item-disabled-color;
-    text-decoration: none;
-  }
 }

--- a/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -7,13 +7,13 @@ exports[`<Popover /> snapshots renders correctly 1`] = `
 >
   <button
     aria-describedby="guid"
-    class="popover-trigger a"
+    class="popover-trigger"
     type="button"
   >
     Toggle
   </button>
   <div
-    class="popover-positioned-container"
+    class="popover-content-container"
   >
     <div
       aria-hidden="true"

--- a/src/Popover/popover.scss
+++ b/src/Popover/popover.scss
@@ -18,7 +18,7 @@
   // Directional styles
 
   &.top {
-    .popover-positioned-container {
+    .popover-content-container {
       bottom: 100%;
       justify-content: center;
     }
@@ -41,7 +41,7 @@
   }
 
   &.right {
-    .popover-positioned-container {
+    .popover-content-container {
       left: 100%;
       align-items: center;
     }
@@ -61,7 +61,7 @@
   }
 
   &.bottom {
-    .popover-positioned-container {
+    .popover-content-container {
       top: 100%;
       justify-content: center;
     }
@@ -81,7 +81,7 @@
   }
 
   &.left {
-    .popover-positioned-container {
+    .popover-content-container {
       right: 100%;
       align-items: center;
     }
@@ -102,8 +102,14 @@
   }
 }
 
+// --- Popover trigger ------------------------------------
+
+.popover-trigger {
+  @include active-trigger-element;
+}
+
 // Content container overrides the width constraints for parent element
-.popover-positioned-container {
+.popover-content-container {
   width: $popover-max-width;
   position: absolute;
   display: inline-flex;

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -24,29 +24,28 @@ Tabs.ContentContainer = simpleComponent('TabsContentContainer', {
  */
 Tabs.Content = activeContent('tabs', {
   arias: { hidden: true, role: 'tabpanel' },
-  baseClass: 'tabs-content',
+  variant: 'tabs-content',
 })
 
 /**
  * [Tabs nav component 📝](https://componentry.design/components/tabs)
  */
-Tabs.Nav = function TabsNav(props) {
+Tabs.TriggersContainer = function TriggersContainer(props) {
   return elem({
-    as: 'nav',
     role: 'tablist',
-    elemClassName: ['tabs-nav', navClasses(props)],
-    ...useTheme('TabsNav'),
+    elemClassName: navClasses('tabs-triggers-container', props),
+    ...useTheme('TriggersContainer'),
     ...props,
   })
 }
-Tabs.Nav.displayName = 'TabsNav'
+Tabs.TriggersContainer.displayName = 'TriggersContainer'
 
 /**
  * [Tabs trigger component 📝](https://componentry.design/components/tabs)
  */
 Tabs.Trigger = activeTrigger('tabs', {
   arias: { selected: true, role: 'tab' },
-  baseClass: 'tabs-trigger',
+  variant: 'tabs-trigger',
   // Tabs can only activate, they never deactivate when clicked
   action: 'activate',
 })

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -6,7 +6,7 @@ import elementTests from '../../test/element-tests'
 
 describe('<Tab />', () => {
   elementTests(Tabs)
-  elementTests(Tabs.Nav)
+  elementTests(Tabs.TriggersContainer)
   elementTests(Tabs.Trigger)
   elementTests(Tabs.ContentContainer)
   elementTests(Tabs.Content)
@@ -18,14 +18,14 @@ describe('<Tab /> snapshots', () => {
   it('renders correctly', () => {
     const { container } = render(
       <Tabs defaultActive='one'>
-        <Tabs.Nav>
+        <Tabs.TriggersContainer>
           <Tabs.Trigger activeId='one'>Item 1</Tabs.Trigger>
           <Tabs.Trigger activeId='two'>Tab with long name</Tabs.Trigger>
           <Tabs.Trigger activeId='three'>Item 3</Tabs.Trigger>
           <Tabs.Trigger disabled activeId='four'>
             Disabled
           </Tabs.Trigger>
-        </Tabs.Nav>
+        </Tabs.TriggersContainer>
         <Tabs.ContentContainer>
           <Tabs.Content activeId='one'>Tab 1</Tabs.Content>
           <Tabs.Content activeId='two'>Tab 2</Tabs.Content>

--- a/src/Tabs/Tabs.stories.mdx
+++ b/src/Tabs/Tabs.stories.mdx
@@ -8,14 +8,14 @@ import Tabs from './Tabs'
 <DocsTitle title='Tabs' experimental />
 
 <Tabs defaultActive='one' className='w-100'>
-  <Tabs.Nav fill={boolean('fill', false)} justify={boolean('justify', false)}>
+  <Tabs.TriggersContainer fill={boolean('fill', false)} justify={boolean('justify', false)}>
     <Tabs.Trigger activeId='one'>Item 1</Tabs.Trigger>
     <Tabs.Trigger activeId='two'>Tab with long name</Tabs.Trigger>
     <Tabs.Trigger activeId='three'>Item 3</Tabs.Trigger>
     <Tabs.Trigger activeId='four' disabled>
       Disabled
     </Tabs.Trigger>
-  </Tabs.Nav>
+  </Tabs.TriggersContainer>
   <Tabs.ContentContainer>
     <Tabs.Content activeId='one'>Tab 1</Tabs.Content>
     <Tabs.Content activeId='two'>Tab 2</Tabs.Content>

--- a/src/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -6,14 +6,14 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
   data-id="guid"
   name="tabs"
 >
-  <nav
-    class="tabs-nav"
+  <div
+    class="tabs-triggers-container"
     role="tablist"
   >
     <button
       aria-controls="guid-one-content"
       aria-selected="true"
-      class="tabs-trigger a active"
+      class="tabs-trigger active"
       id="guid-one-tab"
       role="tab"
       type="button"
@@ -24,7 +24,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <button
       aria-controls="guid-two-content"
       aria-selected="false"
-      class="tabs-trigger a"
+      class="tabs-trigger"
       id="guid-two-tab"
       role="tab"
       type="button"
@@ -35,7 +35,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <button
       aria-controls="guid-three-content"
       aria-selected="false"
-      class="tabs-trigger a"
+      class="tabs-trigger"
       id="guid-three-tab"
       role="tab"
       type="button"
@@ -46,7 +46,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <button
       aria-controls="guid-four-content"
       aria-selected="false"
-      class="tabs-trigger a disabled"
+      class="tabs-trigger disabled"
       disabled=""
       id="guid-four-tab"
       role="tab"
@@ -55,7 +55,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     >
       Disabled
     </button>
-  </nav>
+  </div>
   <div
     class="tabs-content-container"
   >

--- a/src/Tabs/tabs.scss
+++ b/src/Tabs/tabs.scss
@@ -6,7 +6,7 @@
 
 // --- Structure
 // .tabs
-// .tabs-nav
+// .tabs-triggers-container
 // .tabs-trigger
 // .tabs-content-container
 // .tabs-content
@@ -16,21 +16,23 @@
 //
 
 // Container handles: margin between tabs and panes, and layout of tabs
-.tabs-nav {
+.tabs-triggers-container {
   display: flex;
   margin: $tabs-nav-container-margin;
   border-bottom: $tabs-nav-container-border;
   background: $tabs-nav-container-bg;
   box-shadow: $tabs-nav-container-shadow;
 
-  &.nav-fill {
+  // --- Filled
+  &.tabs-triggers-container-fill {
     .tabs-trigger {
       flex: 1 1 auto;
       text-align: center;
     }
   }
 
-  &.nav-justified {
+  // --- Justified
+  &.tabs-triggers-container-justified {
     .tabs-trigger {
       flex-basis: 0;
       flex-grow: 1;
@@ -38,9 +40,10 @@
     }
   }
 
-  // Provide ability to customize tab styles for vertical tabs, they likely look
-  // different
-  &.nav-vertical {
+  // TODO: tabs pills
+
+  // --- Vertical
+  &.tabs-triggers-container-vertical {
     margin: $tabs-nav-vertical-margin;
     border-bottom: none;
 
@@ -82,6 +85,8 @@
   padding: $tabs-tab-padding-y $tabs-tab-padding-x;
   background: $tabs-tab-bg;
   color: $tabs-tab-color;
+  font-size: $font-size-base;
+  font-weight: $font-weight-normal;
   border-style: solid;
   border-color: $tabs-tab-border-color;
   border-width: $tabs-tab-border-width;

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -5,9 +5,7 @@ import { useTheme } from '../Theme/Theme'
  * [Text component 📝](https://componentry.design/components/text)
  */
 export default function Text(props) {
-  const { color, inline, size, variant, ...rest } = {
-    as: 'p',
-    variant: 'body',
+  const { variant = 'body', color, inline, size, ...rest } = {
     ...useTheme('Text'),
     ...props,
   }
@@ -16,6 +14,6 @@ export default function Text(props) {
   if (color) rest.fontColor = color
   if (size) rest.fontSize = size
 
-  return elem({ elemClassName: variant, ...rest })
+  return elem({ as: 'p', elemClassName: variant, ...rest })
 }
 Text.displayName = 'Text'

--- a/src/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -7,13 +7,13 @@ exports[`<Tooltip /> snapshots renders correctly 1`] = `
 >
   <button
     aria-describedby="guid"
-    class="tooltip-trigger a"
+    class="tooltip-trigger"
     type="button"
   >
     Trigger
   </button>
   <div
-    class="tooltip-positioned-container"
+    class="tooltip-content-container"
   >
     <div
       aria-hidden="true"

--- a/src/Tooltip/tooltip.scss
+++ b/src/Tooltip/tooltip.scss
@@ -12,8 +12,14 @@
   position: relative;
 }
 
+// --- Tooltip trigger ------------------------------------
+
+.tooltip-trigger {
+  @include active-trigger-element;
+}
+
 // Content container overrides the width constraints for parent element
-.tooltip-positioned-container {
+.tooltip-content-container {
   width: $tooltip-max-width;
   position: absolute;
 }

--- a/src/active-container-factory.js
+++ b/src/active-container-factory.js
@@ -24,6 +24,7 @@ export const ActiveCtx = createContext({ active: false })
  * context as the `activate` and `deactivate` handlers for subcomponents to _always_
  * use. This ensures that we can always hook into the change events for internal
  * needs like setting or removing special event listeners.
+ * @returns {import('react').FunctionComponent<any>}
  */
 export default function activeContainerFactory(name, opts = {}) {
   const themeName = `${name.slice(0, 1).toUpperCase()}${name.slice(1)}`

--- a/src/active-content-factory.js
+++ b/src/active-content-factory.js
@@ -6,23 +6,22 @@ import { useTheme } from './Theme/Theme'
 
 /**
  * Factory returns custom `<Content />` components defined by the options.
+ * @returns {import('react').FunctionComponent<any>}
  */
 export default function ActiveContentFactory(
-  component,
+  name,
   {
     // Map of aria attributes to render with component
     arias,
-    // The base css class for this component
-    baseClass = `${component}-content`,
     // The component name used for display and theme lookups
-    name = `${component.slice(0, 1).toUpperCase()}${component.slice(1)}Content`,
+    displayName = `${name.slice(0, 1).toUpperCase()}${name.slice(1)}Content`,
     // Switch to include an absolute positioned wrapper for positioning+width styles
     positioned = false,
   } = {},
 ) {
   function ActiveContent(props) {
-    const { active, activeId, children, guid, ...rest } = {
-      ...useTheme(name),
+    const { active, activeId, children, guid, variant = `${name}-content`, ...rest } = {
+      ...useTheme(displayName),
       ...useContext(ActiveCtx),
       ...props,
     }
@@ -37,7 +36,7 @@ export default function ActiveContentFactory(
         type: 'content',
         arias,
       }),
-      elemClassName: baseClass,
+      elemClassName: variant,
       children: (
         <>
           {positioned && (
@@ -57,11 +56,11 @@ export default function ActiveContentFactory(
       // This className works right now b/c we're only passing a single className
       // in classes, but this is fragile... would be nice to be more explicity but
       // not add in unnecessary factory config code.
-      <div className={`${component}-positioned-container`}>{content}</div>
+      <div className={`${name}-content-container`}>{content}</div>
     ) : (
       content
     )
   }
-  ActiveContent.displayName = name
+  ActiveContent.displayName = displayName
   return ActiveContent
 }

--- a/src/active-trigger-factory.js
+++ b/src/active-trigger-factory.js
@@ -8,14 +8,13 @@ import { actionClasses, elemArias } from './utils/componentry'
  * Factory returns custom `<Trigger />` components defined by the fn options.
  * Componentry sets up triggers to be anchor style buttons by default, this
  * can be overridden by passing an as, type and anchor to reset the defaults.
+ * @returns {import('react').FunctionComponent<any>}
  */
 export default function activeTriggerFactory(
   name,
   {
     // Map of aria attributes to render with component
     arias = {},
-    // Component name className
-    baseClass = `${name}-trigger`,
     // Theme lookups and component display name
     displayName = `${name.slice(0, 1).toUpperCase()}${name.slice(1)}Trigger`,
     // Overrides component onClick to specified activate/deactivate action
@@ -25,6 +24,9 @@ export default function activeTriggerFactory(
 ) {
   function ActiveTrigger(props) {
     const {
+      as = 'button',
+      type = 'button',
+      variant = `${name}-trigger`,
       // --- Render elements
       children,
       decoration,
@@ -36,9 +38,6 @@ export default function activeTriggerFactory(
       deactivate,
       ...rest
     } = {
-      as: 'button',
-      type: 'button',
-      variant: 'a',
       ...opts,
       ...useTheme(displayName),
       ...useContext(ActiveCtx),
@@ -55,6 +54,8 @@ export default function activeTriggerFactory(
     else onClick = active ? deactivate : activate
 
     return elem({
+      as,
+      type,
       ...elemArias({
         active,
         activeId,
@@ -63,8 +64,7 @@ export default function activeTriggerFactory(
         arias,
       }),
       elemClassName: [
-        baseClass,
-        actionClasses(rest),
+        actionClasses(variant, rest),
         // For compound-active contexts add an active class if activeIds match
         // (eg in tabs show which tab is selected)
         { active: activeId && active === activeId },

--- a/src/simple-component-factory.js
+++ b/src/simple-component-factory.js
@@ -1,9 +1,16 @@
 import elem from './elem-factory'
 import { useTheme } from './Theme/Theme'
 
-export default function simpleComponent(name, defaults) {
+/**
+ * Generate a library component with no dynamic behaviors
+ * @param {string} name
+ * @param {Object} propsDefaults Library defaults, overridden by theme defaults
+ *  then instance props
+ * @returns {import('react').FunctionComponent<any>}
+ */
+export default function simpleComponent(name, propsDefaults) {
   function Component(props) {
-    return elem({ ...defaults, ...useTheme(name), ...props })
+    return elem({ ...propsDefaults, ...useTheme(name), ...props })
   }
   Component.displayName = name
 

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -159,23 +159,55 @@
 // Action elements
 
 /** Resets button and anchor styles to baseline */
-@mixin reset-action-item {
-  // button reset
-  -webkit-appearance: button;
-  border-radius: 0;
+@mixin reset-button {
+  -webkit-appearance: none !important; // Remove Chrome native button styling
+  display: inline; // Match browser agent display for <a>
+  padding: 0; // Remove browser agent padding
+
+  // Reset button font styles
   font-family: inherit;
-  font-size: $font-size-base;
-  line-height: $line-height-base;
-  margin: 0;
-  overflow: visible;
-  text-transform: none;
   font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  text-align: inherit;
+  text-transform: none;
 
-  // anchor reset
-  text-decoration: none;
+  white-space: normal; // Reset .btn white space
 
-  &:not(:disabled) {
-    cursor: pointer; // 3
+  // TODO: is there a way to make it so that selecting button text doesn't show
+  // cursor pointer the same that way that selecting anchor text works?
+  user-select: auto;
+
+  // Reset button borders and background
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
+}
+
+// Creates default styles for all the active trigger components to look like
+// anchors
+@mixin active-trigger-element {
+  @include reset-button;
+
+  // Set anchor font styles
+  color: typography-color(anchor);
+
+  &:hover,
+  &.hover {
+    color: $anchor-hover-color;
+    text-decoration: $anchor-hover-decoration;
+  }
+
+  &:active,
+  &.active {
+    color: $anchor-active-color;
+    text-decoration: $anchor-active-decoration;
+  }
+
+  &.disabled {
+    color: typography-color(disabled);
+    text-decoration: $anchor-disabled-decoration;
   }
 }
 

--- a/src/styles/_reboot.scss
+++ b/src/styles/_reboot.scss
@@ -283,6 +283,14 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  -webkit-appearance: button;
+  cursor: pointer;
+}
+
 // 1. Remove the margin in Firefox and Safari
 
 input,

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -16,7 +16,6 @@
 // --------------------------------------------------------
 // Design system options
 
-$enable-dom-styles:    true !default;
 $enable-rounded:       true !default;
 $enable-shadows:       true !default;
 $enable-transitions:   true !default;
@@ -350,7 +349,7 @@ $btn-active-decoration: none !default;
 
 $btn-disabled-opacity: 0.65 !default;
 $btn-disabled-border-width: $btn-border-width !default;
-$btn-link-disabled-color: font-color(disabled) !default;
+$btn-link-disabled-color: typography-color(disabled) !default;
 
 $btn-padding-y-sm: 0.25rem !default;
 $btn-padding-x-sm: 0.5rem !default;
@@ -457,7 +456,7 @@ $dropdown-item-padding-x-lg: ($dropdown-item-padding-x * 1.1) !default;
 // Dropdown items are assumed to be action elements (a or btn), default styling
 // is to not override the action element styles, but user's can define dropdown
 // action item specific styles with these variables.
-$dropdown-action-item-color:        null !default;
+$dropdown-action-item-color:        typography-color(anchor) !default;
 $dropdown-action-item-hover-color:  null !default;
 $dropdown-action-item-hover-bg:     darken(theme-color(background), 7.5%) !default;
 
@@ -562,19 +561,20 @@ $list-border-radius: $border-radius !default;
 $list-item-padding-y: 0.75rem !default;
 $list-item-padding-x: 1.25rem !default;
 
-$list-hover-bg: gray('100') !default;
-$list-active-color: $active-foreground !default;
-$list-active-bg: $active-background !default;
-$list-active-border-color: $list-active-bg !default;
+$list-action-item-color: gray('700') !default;
 
-$list-disabled-color: gray('600') !default;
-$list-disabled-bg: $list-bg !default;
+$list-action-item-hover-color: $list-action-item-color !default;
+$list-action-item-hover-bg: gray('100') !default;
 
-$list-action-color: gray('700') !default;
-$list-action-hover-color: $list-action-color !default;
+$list-action-item-active-color: theme-color(foreground) !default;
+$list-action-item-active-bg: gray('200') !default;
 
-$list-action-active-color: theme-color(foreground) !default;
-$list-action-active-bg: gray('200') !default;
+$list-active-item-color: $active-foreground !default;
+$list-active-item-bg: $active-background !default;
+$list-active-item-border-color: $list-active-item-bg !default;
+
+$list-disabled-item-color: gray('600') !default;
+$list-disabled-item-bg: $list-bg !default;
 
 // --------------------------------------------------------
 // Modals

--- a/src/styles/utility/_visibility.scss
+++ b/src/styles/utility/_visibility.scss
@@ -45,6 +45,7 @@
   // styles to initial), individual elements should add specific disabled styles
   // for color, bg, etc.
   pointer-events: none;
+  cursor: default;
 }
 
 //

--- a/src/utils/componentry.js
+++ b/src/utils/componentry.js
@@ -1,33 +1,117 @@
+import cx from 'classnames'
+
 /**
  * Library utility functions for working with props to className+style mappings
  * @module
  */
 
+// --------------------------------------------------------
+// Component arias generator
+
+/**
+ * Return object of aria attributes using options
+ * @param {Object} opts
+ * @param {boolean|string} opts.active
+ * @param {string} [opts.activeId]
+ * @param {string} opts.guid
+ * @param {string} [opts.type] Oneof 'trigger' or 'content'
+ * @param {Object} opts.arias
+ * @param {boolean} [opts.arias.controls]
+ * @param {boolean} [opts.arias.describedby]
+ * @param {boolean} [opts.arias.expanded]
+ * @param {boolean} [opts.arias.haspopup]
+ * @param {boolean} [opts.arias.hidden]
+ * @param {boolean} [opts.arias.id]
+ * @param {boolean} [opts.arias.labelledby]
+ * @param {string} [opts.arias.role]
+ * @param {boolean} [opts.arias.selected]
+ */
+export function elemArias({ active, activeId, guid, type, arias = {} }) {
+  const {
+    controls,
+    describedby,
+    expanded,
+    haspopup,
+    hidden,
+    id,
+    labelledby,
+    role,
+    selected,
+  } = arias
+  const _arias = {}
+
+  if (controls) _arias['aria-controls'] = guid
+  if (describedby) _arias['aria-describedby'] = guid
+  if (expanded) _arias['aria-expanded'] = String(active)
+  if (haspopup) _arias['aria-haspopup'] = 'true'
+  if (hidden) _arias['aria-hidden'] = String(!active)
+  if (id) _arias.id = guid
+  if (labelledby) _arias['aria-labelledby'] = guid
+  if (role) _arias.role = role
+  if (selected) _arias['aria-selected'] = String(active)
+
+  // For elements with multiple trigger/content groups an activeId is used to
+  // track which group is active. Aria values must include addl identifiers
+  // to ensure uniqueness
+  if (activeId && type === 'trigger') {
+    _arias.id = `${guid}-${activeId}-tab`
+    _arias['aria-controls'] = `${guid}-${activeId}-content`
+    _arias['aria-selected'] = String(active === activeId)
+  } else if (activeId && type === 'content') {
+    _arias.id = `${guid}-${activeId}-content`
+    _arias['aria-labelledby'] = `${guid}-${activeId}-trigger`
+    _arias['aria-hidden'] = String(activeId !== active)
+  }
+
+  return _arias
+}
+
 /**
  * Fn generates the classes for action elements
+ * @param {string} variant
+ * @param {Object} opts
+ * @param {boolean} [opts.active]
+ * @param {boolean} [opts.block]
+ * @param {string} [opts.color]
+ * @param {boolean} [opts.disabled]
+ * @param {string} [opts.outline]
+ * @param {string} [opts.size]
+ * @returns {string}
  */
-export function actionClasses({ block, color, disabled, outline, size, variant }) {
-  return {
+export function actionClasses(
+  variant,
+  { active, block, color, disabled, outline, size },
+) {
+  return cx({
     [variant]: true,
     [`${variant}-block`]: block,
     [`${variant}-${color}`]: color,
     [`${variant}-outline-${outline}`]: outline,
     [`${variant}-${size}`]: size,
+    active,
     // We include a disabled class AND pass disabled prop to btn element for a11y
     disabled,
-  }
+  })
 }
 
 /**
  * Function generates the classes for nav elements
+ * @param {string} variant
+ * @param {Object} opts
+ * @param {boolean} [opts.fill]
+ * @param {boolean} [opts.justify]
+ * @param {boolean} [opts.pills]
+ * @param {boolean} [opts.vertical]
+ * @returns {string}
  */
-export function navClasses({ fill, justify, pills, vertical }) {
-  return {
-    'nav-vertical': vertical,
-    'nav-pills': pills,
-    'nav-fill': fill,
-    'nav-justified': justify,
-  }
+export function navClasses(variant, { fill, justify, pills, vertical }) {
+  return cx({
+    [variant]: true,
+    [`${variant}-fill`]: fill,
+    [`${variant}-justified`]: justify,
+    [`${variant}-pills`]: pills,
+    [`${variant}-vertical`]: vertical,
+  })
 }
 
 // --------------------------------------------------------
@@ -183,50 +267,4 @@ export function componentry({
     rest,
     libraryStyles: styles,
   }
-}
-
-// --------------------------------------------------------
-// Component arias generator
-
-/**
- * Return object of aria attributes using options
- */
-export function elemArias({ active, activeId, guid, type, arias = {} }) {
-  const {
-    controls,
-    describedby,
-    expanded,
-    haspopup,
-    hidden,
-    id,
-    labelledby,
-    role,
-    selected,
-  } = arias
-  const _arias = {}
-
-  if (controls) _arias['aria-controls'] = guid
-  if (describedby) _arias['aria-describedby'] = guid
-  if (expanded) _arias['aria-expanded'] = String(active)
-  if (haspopup) _arias['aria-haspopup'] = 'true'
-  if (hidden) _arias['aria-hidden'] = String(!active)
-  if (id) _arias.id = guid
-  if (labelledby) _arias['aria-labelledby'] = guid
-  if (role) _arias.role = role
-  if (selected) _arias['aria-selected'] = String(active)
-
-  // For elements with multiple trigger/content groups an activeId is used to
-  // track which group is active. Aria values must include addl identifiers
-  // to ensure uniqueness
-  if (activeId && type === 'trigger') {
-    _arias.id = `${guid}-${activeId}-tab`
-    _arias['aria-controls'] = `${guid}-${activeId}-content`
-    _arias['aria-selected'] = String(active === activeId)
-  } else if (activeId && type === 'content') {
-    _arias.id = `${guid}-${activeId}-content`
-    _arias['aria-labelledby'] = `${guid}-${activeId}-trigger`
-    _arias['aria-hidden'] = String(activeId !== active)
-  }
-
-  return _arias
 }

--- a/src/utils/componentry.spec.js
+++ b/src/utils/componentry.spec.js
@@ -1,4 +1,4 @@
-import { actionClasses, componentry, elemArias } from './componentry'
+import { actionClasses, componentry, elemArias, navClasses } from './componentry'
 
 describe('componentry()', () => {
   test('computes libary utility classes from props', () => {
@@ -178,24 +178,33 @@ describe('componentry()', () => {
 })
 
 describe('actionClasses()', () => {
-  test('actionClasses returns computed className values for target elements', () => {
+  test('actionClasses returns computed className for passed options', () => {
     expect(
-      actionClasses({
-        variant: 'btn',
+      actionClasses('btn', {
+        active: true,
         block: true,
         color: 'primary',
         disabled: true,
         outline: 'primary',
         size: 'sm',
       }),
-    ).toEqual({
-      btn: true,
-      'btn-block': true,
-      'btn-primary': 'primary',
-      disabled: true,
-      'btn-outline-primary': 'primary',
-      'btn-sm': 'sm',
-    })
+    ).toEqual('btn btn-block btn-primary btn-outline-primary btn-sm active disabled')
+  })
+
+  test('when no truthy values are passed, then only the variant is returned', () => {
+    expect(actionClasses('btn', {})).toEqual('btn')
+  })
+})
+
+describe('navClasses()', () => {
+  test('navClasses returns computed className for passed options', () => {
+    expect(
+      navClasses('nav', { fill: true, justify: true, pills: true, vertical: true }),
+    ).toEqual('nav nav-fill nav-justified nav-pills nav-vertical')
+  })
+
+  test('when no truthy values are passed, then only the variant is returned', () => {
+    expect(navClasses('nav', {})).toEqual('nav')
   })
 })
 
@@ -215,6 +224,7 @@ describe('arias()', () => {
     const attrs = {
       active: true,
       guid: 'test',
+      arias: {},
     }
 
     const result = elemArias(attrs)


### PR DESCRIPTION
## Items

_On Dropdown.Item, List.Item, Nav.Item_

At this time Item components are not abstracted into some factory because there are enough
differences that it isn't value added.

- Dropdown content by default is not assumed to be a list, Dropdowns may have lists in
  them, but they may also have headers, form elements, text, etc. Interactive dropdown
  items are also most likely to be a button.
- List content is assumed to be a list, but may be a list of text, anchors or buttons.
  Although the default container is a `ul`, it's technically invalid HTML to include
  anything other than an `li` in an unordered list.
- Nav content is assumed to be a set of links, and is not structured as a list. Nav items
  are assumed to be `a` elements within `nav` container that provides some shortcut layout
  options.
- Tabs don't have items, under the hood the tabs list used to be a nav container, but it no longer is.