### PR TITLE
Update: Rename 'System' to 'Utilities'

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,7 +13,7 @@
 
 ## Small upgrades
 
-- Add System props for `flex-grow`, and `flex-shrink`.
+- Add utility props for `flex-grow`, and `flex-shrink`.
 - Add fullWidth prop that sets a `.min-w-full` class for 100% width
 - Rename direction props to `placement-<direction>`
 

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -48,7 +48,7 @@ export const Alert: Alert = (props) => {
 
   const { active, visible } = useVisible(propsActive)
 
-  return element('Alert', {
+  return element({
     'role': 'alert',
     'componentCx': [
       `🅲Alert-base 🅲Alert-${variant}`,

--- a/src/components/Badge/Badge.ts
+++ b/src/components/Badge/Badge.ts
@@ -23,7 +23,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     ...props,
   }
 
-  return element('Badge', {
+  return element({
     componentCx: [`badge-${variant}`, { [`badge-color-${color}`]: color }],
     ...rest,
   })

--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -17,7 +17,7 @@ export const Block: React.FC<BlockProps> = (props) => {
     ...props,
   }
 
-  return element('Block', {
+  return element({
     componentCx: {
       'block': !inline,
       'inline-block': inline,

--- a/src/components/Button/Button.ts
+++ b/src/components/Button/Button.ts
@@ -33,7 +33,7 @@ export const Button: React.FC<ButtonProps> = (props) => {
     ...props,
   }
 
-  return element<ButtonProps>('Button', {
+  return element({
     // If an href is passed, this instance should render an anchor tag
     as: merged.href ? 'a' : 'button',
     type: merged.href ? undefined : 'button',

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -28,7 +28,7 @@ export const Flex: React.FC<FlexProps> = (props) => {
   // => so props use "column" and we replace with "col"
   const computedDirection = direction?.replace('column', 'col')
 
-  return element('Flex', {
+  return element({
     componentCx: {
       'flex': !inline,
       'inline-flex': inline,

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -23,7 +23,7 @@ export const Grid: React.FC<GridProps> = (props) => {
     ...props,
   }
 
-  return element('Grid', {
+  return element({
     componentCx: {
       'grid': !inline,
       'inline-grid': inline,

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -28,7 +28,7 @@ export const Icon: React.FC<Props> = (props) => {
     ...rest
   } = { ...useTheme<Props>('Icon'), ...props }
 
-  return element('Icon', {
+  return element({
     as: 'svg',
     role: 'img',
     componentCx: [

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -69,7 +69,7 @@ Input.Field = function InputField(props) {
   const ctx = useContext(InputCtx)
   assertContext(ctx)
 
-  return element('InputField', {
+  return element({
     as: 'input',
     type: 'text',
     id: ctx.guid, // aria -> htmlFor
@@ -85,7 +85,7 @@ Input.Label = function InputLabel(props) {
   const ctx = useContext(InputCtx)
   assertContext(ctx)
 
-  return element('InputLabel', {
+  return element({
     as: 'label',
     htmlFor: ctx.guid, // aria -> id
     ...useTheme<InputLabelProps>('InputLabel'),

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -23,7 +23,7 @@ export const Link: React.FC<LinkProps> = (props) => {
     ...props,
   }
 
-  return element('Link', {
+  return element({
     as: merged.href ? 'a' : 'button',
     type: merged.href ? undefined : 'button',
     componentCx: `🅲Link-base 🅲Link-${variant}`,

--- a/src/components/List/List.ts
+++ b/src/components/List/List.ts
@@ -36,7 +36,7 @@ export interface List {
 export const List: List = (props) => {
   const { flush, ...rest } = { ...useTheme('List'), ...props }
 
-  return element('List', {
+  return element({
     componentCx: { 'list-flush': flush },
     ...rest,
   })
@@ -49,7 +49,7 @@ List.displayName = 'List'
 List.Item = function ListItem(props) {
   const { active, color, disabled, ...rest } = { ...useTheme('ListItem'), ...props }
 
-  return element('ListItem', {
+  return element({
     as: rest.href || rest.to ? 'a' : 'button',
     componentCx: {
       [`list-item-${color}`]: color,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -110,7 +110,7 @@ export const Modal = ((props: ModalProps): JSX.Element => {
   //     div.modal-container - Contains the modal header,body,footer elements
   return (
     <ModalCtx.Provider value={{ active, deactivate, guid }}>
-      {element('ModalOverlay', {
+      {element({
         'onClick': deactivate,
         'componentCx': ['fade', `modal-${scroll}-scroll`, { visible }],
         'aria-hidden': String(!active),
@@ -160,7 +160,7 @@ Modal.Header = function ModalHeader(props: ModalHeaderProps) {
   const ctx = useContext(ModalCtx)
   assertContext(ctx)
 
-  return element('ModalHeader', {
+  return element({
     children: (
       <>
         {children}
@@ -181,7 +181,7 @@ Modal.Title = function ModalTitle(props) {
   const ctx = useContext(ModalCtx)
   assertContext(ctx)
 
-  return element('ModalTitle', {
+  return element({
     as: 'h2',
     id: ctx.guid,
     ...useTheme<ModalTitleProps>('Modaltitle'),
@@ -200,7 +200,7 @@ Modal.Body = function ModalBody(props) {
 
   useActiveScrollReset(ctx.active, bodyRef)
 
-  return element('ModalBody', {
+  return element({
     ref: bodyRef,
     ...useTheme<ModalBodyProps>('ModalBody'),
     ...props,

--- a/src/components/Nav/Nav.ts
+++ b/src/components/Nav/Nav.ts
@@ -26,7 +26,7 @@ export interface Nav {
  * @experimental
  */
 export const Nav = ((props: NavProps) => {
-  return element('Nav', {
+  return element({
     as: 'nav',
     componentCx: navClasses('nav', props),
     role: 'navigation',
@@ -42,7 +42,7 @@ Nav.Item = function NavItem(props) {
     ...props,
   }
 
-  return element('NavItem', {
+  return element({
     as: 'a',
     componentCx: `nav-item-${variant}`,
     ...merged,

--- a/src/components/Tabs/Tabs.ts
+++ b/src/components/Tabs/Tabs.ts
@@ -64,7 +64,7 @@ export interface Tabs {
 export const Tabs = activeContainerBuilder<TabsProps>('Tabs') as Tabs
 
 const ActionsContainer: React.FC<TabsActionsContainerProps> = (props) => {
-  return element('TabsActionsContainer', {
+  return element({
     role: 'tablist',
     componentCx: navClasses('tabs-actions-container', props),
     ...useTheme<TabsActionsContainerProps>('TabsActionsContainer'),

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -38,7 +38,7 @@ export const Text: React.FC<Props> = (props) => {
     ...props,
   }
 
-  return element('Text', {
+  return element({
     as: elementsMap[variant],
     componentCx: `🅲Text-base 🅲Text-${variant}`,
     ...rest,

--- a/src/plugin-babel/plugin.ts
+++ b/src/plugin-babel/plugin.ts
@@ -4,7 +4,7 @@ import { PluginObj, types } from '@babel/core'
 import { Flex } from '../components/Flex/Flex'
 import { Block } from '../components/Block/Block'
 import { Text } from '../components/Text/Text'
-import { precompileProps, utilityProps } from '../utils/componentry'
+import { precompileProps, utilityProps } from '../utils/style-utilities'
 
 import { parseAttributes } from './parse-attributes'
 import { buildClosingElement, buildOpeningElement } from './build-elements'

--- a/src/utils/active-action-component-builder.tsx
+++ b/src/utils/active-action-component-builder.tsx
@@ -54,7 +54,7 @@ export function activeActionBuilder<TProps extends ActiveActionBaseProps>(
     else if (activeId) onClick = activeId === active ? deactivate : activate
     else onClick = active ? deactivate : activate
 
-    return element(displayName, {
+    return element({
       as,
       type,
       ...computeARIA({

--- a/src/utils/active-container-component-builder.tsx
+++ b/src/utils/active-container-component-builder.tsx
@@ -209,7 +209,7 @@ export function activeContainerBuilder<TProps extends ActiveContainerBaseProps>(
     // TODO: only wrap elements with a `div` when the element needs it
     return (
       <ActiveCtx.Provider value={activeValues}>
-        {element(displayName, {
+        {element({
           'data-id': guid,
           'componentCx': {
             [`${baseCx}-${size}`]: size,

--- a/src/utils/active-content-component-builder.tsx
+++ b/src/utils/active-content-component-builder.tsx
@@ -38,7 +38,7 @@ export function activeContentBuilder<TProps extends ActiveContentBaseProps>(
 
     // Create component content (return optionally wraps content in a width busting
     // container)
-    const content = element(displayName, {
+    const content = element({
       ...computeARIA({
         active,
         activeId,

--- a/src/utils/componentry.spec.js
+++ b/src/utils/componentry.spec.js
@@ -1,27 +1,27 @@
-import { componentry } from './componentry'
+import { utilityStyles } from './style-utilities'
 
 const sizes = ['xs', 'sm', 'md', 'lg', 'xl']
 
-describe('componentry()', () => {
-  it('computes libary utility classes from props', () => {
+describe('utilityStyles()', () => {
+  it('computes library utility classes from props', () => {
     sizes.forEach((size) => {
-      expect(componentry({ m: size, p: size }).utilityCx[1]).toStrictEqual([
+      expect(utilityStyles({ m: size, p: size }).utilityCx[1]).toStrictEqual([
         `m-${size}`,
         `p-${size}`,
       ])
 
-      expect(componentry({ mx: size, px: size }).utilityCx[1]).toStrictEqual([
+      expect(utilityStyles({ mx: size, px: size }).utilityCx[1]).toStrictEqual([
         `mx-${size}`,
         `px-${size}`,
       ])
 
-      expect(componentry({ my: size, py: size }).utilityCx[1]).toStrictEqual([
+      expect(utilityStyles({ my: size, py: size }).utilityCx[1]).toStrictEqual([
         `my-${size}`,
         `py-${size}`,
       ])
 
       expect(
-        componentry({
+        utilityStyles({
           mt: size,
           mr: size,
           mb: size,
@@ -45,101 +45,101 @@ describe('componentry()', () => {
   })
 
   it('passes through numeric margin, and padding values', () => {
-    expect(componentry({ m: 5, p: 5 }).styles).toStrictEqual({
+    expect(utilityStyles({ m: 5, p: 5 }).styles).toStrictEqual({
       margin: 5,
       padding: 5,
     })
-    expect(componentry({ mx: 5, px: 5 }).styles).toStrictEqual({
+    expect(utilityStyles({ mx: 5, px: 5 }).styles).toStrictEqual({
       marginLeft: 5,
       marginRight: 5,
       paddingLeft: 5,
       paddingRight: 5,
     })
-    expect(componentry({ my: 5, py: 5 }).styles).toStrictEqual({
+    expect(utilityStyles({ my: 5, py: 5 }).styles).toStrictEqual({
       marginTop: 5,
       marginBottom: 5,
       paddingTop: 5,
       paddingBottom: 5,
     })
-    expect(componentry({ mt: 5 }).styles).toStrictEqual({ marginTop: 5 })
-    expect(componentry({ mr: 5 }).styles).toStrictEqual({ marginRight: 5 })
-    expect(componentry({ mb: 5 }).styles).toStrictEqual({ marginBottom: 5 })
-    expect(componentry({ ml: 5 }).styles).toStrictEqual({ marginLeft: 5 })
-    expect(componentry({ pt: 5 }).styles).toStrictEqual({ paddingTop: 5 })
-    expect(componentry({ pr: 5 }).styles).toStrictEqual({ paddingRight: 5 })
-    expect(componentry({ pb: 5 }).styles).toStrictEqual({ paddingBottom: 5 })
-    expect(componentry({ pl: 5 }).styles).toStrictEqual({ paddingLeft: 5 })
+    expect(utilityStyles({ mt: 5 }).styles).toStrictEqual({ marginTop: 5 })
+    expect(utilityStyles({ mr: 5 }).styles).toStrictEqual({ marginRight: 5 })
+    expect(utilityStyles({ mb: 5 }).styles).toStrictEqual({ marginBottom: 5 })
+    expect(utilityStyles({ ml: 5 }).styles).toStrictEqual({ marginLeft: 5 })
+    expect(utilityStyles({ pt: 5 }).styles).toStrictEqual({ paddingTop: 5 })
+    expect(utilityStyles({ pr: 5 }).styles).toStrictEqual({ paddingRight: 5 })
+    expect(utilityStyles({ pb: 5 }).styles).toStrictEqual({ paddingBottom: 5 })
+    expect(utilityStyles({ pl: 5 }).styles).toStrictEqual({ paddingLeft: 5 })
   })
 
   it('passes through string margin, and padding values', () => {
-    expect(componentry({ m: '5', p: '5' }).styles).toStrictEqual({
+    expect(utilityStyles({ m: '5', p: '5' }).styles).toStrictEqual({
       margin: '5',
       padding: '5',
     })
-    expect(componentry({ mx: '5', px: '5' }).styles).toStrictEqual({
+    expect(utilityStyles({ mx: '5', px: '5' }).styles).toStrictEqual({
       marginLeft: '5',
       marginRight: '5',
       paddingLeft: '5',
       paddingRight: '5',
     })
-    expect(componentry({ my: '5', py: '5' }).styles).toStrictEqual({
+    expect(utilityStyles({ my: '5', py: '5' }).styles).toStrictEqual({
       marginTop: '5',
       marginBottom: '5',
       paddingTop: '5',
       paddingBottom: '5',
     })
-    expect(componentry({ mt: '5' }).styles).toStrictEqual({ marginTop: '5' })
-    expect(componentry({ mr: '5' }).styles).toStrictEqual({ marginRight: '5' })
-    expect(componentry({ mb: '5' }).styles).toStrictEqual({ marginBottom: '5' })
-    expect(componentry({ ml: '5' }).styles).toStrictEqual({ marginLeft: '5' })
-    expect(componentry({ pt: '5' }).styles).toStrictEqual({ paddingTop: '5' })
-    expect(componentry({ pr: '5' }).styles).toStrictEqual({ paddingRight: '5' })
-    expect(componentry({ pb: '5' }).styles).toStrictEqual({ paddingBottom: '5' })
-    expect(componentry({ pl: '5' }).styles).toStrictEqual({ paddingLeft: '5' })
+    expect(utilityStyles({ mt: '5' }).styles).toStrictEqual({ marginTop: '5' })
+    expect(utilityStyles({ mr: '5' }).styles).toStrictEqual({ marginRight: '5' })
+    expect(utilityStyles({ mb: '5' }).styles).toStrictEqual({ marginBottom: '5' })
+    expect(utilityStyles({ ml: '5' }).styles).toStrictEqual({ marginLeft: '5' })
+    expect(utilityStyles({ pt: '5' }).styles).toStrictEqual({ paddingTop: '5' })
+    expect(utilityStyles({ pr: '5' }).styles).toStrictEqual({ paddingRight: '5' })
+    expect(utilityStyles({ pb: '5' }).styles).toStrictEqual({ paddingBottom: '5' })
+    expect(utilityStyles({ pl: '5' }).styles).toStrictEqual({ paddingLeft: '5' })
   })
 
   it('border style classes are computed correctly', () => {
-    expect(componentry({ border: true }).utilityCx[0]).toStrictEqual(
+    expect(utilityStyles({ border: true }).utilityCx[0]).toStrictEqual(
       expect.objectContaining({
         border: true,
       }),
     )
 
-    expect(componentry({ borderTop: true }).utilityCx[0]).toStrictEqual(
+    expect(utilityStyles({ borderTop: true }).utilityCx[0]).toStrictEqual(
       expect.objectContaining({
         'border-t': true,
       }),
     )
-    expect(componentry({ borderRight: true }).utilityCx[0]).toStrictEqual(
+    expect(utilityStyles({ borderRight: true }).utilityCx[0]).toStrictEqual(
       expect.objectContaining({
         'border-r': true,
       }),
     )
-    expect(componentry({ borderBottom: true }).utilityCx[0]).toStrictEqual(
+    expect(utilityStyles({ borderBottom: true }).utilityCx[0]).toStrictEqual(
       expect.objectContaining({
         'border-b': true,
       }),
     )
-    expect(componentry({ borderLeft: true }).utilityCx[0]).toStrictEqual(
+    expect(utilityStyles({ borderLeft: true }).utilityCx[0]).toStrictEqual(
       expect.objectContaining({
         'border-l': true,
       }),
     )
 
-    expect(componentry({ borderColor: 'primary' }).utilityCx[0]).toStrictEqual(
+    expect(utilityStyles({ borderColor: 'primary' }).utilityCx[0]).toStrictEqual(
       expect.objectContaining({
         'border-primary': 'primary',
       }),
     )
 
-    expect(componentry({ borderWidth: 'lg' }).utilityCx[0]).toStrictEqual(
+    expect(utilityStyles({ borderWidth: 'lg' }).utilityCx[0]).toStrictEqual(
       expect.objectContaining({ 'border-lg': 'lg' }),
     )
   })
 
   it('returns library className values', () => {
     expect(
-      componentry({
+      utilityStyles({
         alignContent: 'center',
         alignItems: 'center',
         alignSelf: 'center',

--- a/src/utils/element-creator.tsx
+++ b/src/utils/element-creator.tsx
@@ -1,6 +1,6 @@
 import React, { ForwardedRef, createElement } from 'react'
 import clsx, { type ClassValue } from 'clsx'
-import { componentry } from './componentry'
+import { utilityStyles } from './style-utilities'
 
 // Type used to *constrain* what props can be passed into element()
 type ElementProps = {
@@ -31,21 +31,17 @@ type ElementCreator<Props> = Props & {
  * (This lets us create elements that are very flexible with much less verbose
  * code at the definition site)
  */
-export function element<Props extends ElementProps>(
-  displayName: string,
-  {
-    as = 'div',
-    className,
-    componentCx,
-    style,
-    themeCx,
-    ...merged
-  }: ElementCreator<Props>,
-): React.ReactElement {
+export function element<Props extends ElementProps>({
+  as = 'div',
+  className,
+  componentCx,
+  style,
+  themeCx,
+  ...merged
+}: ElementCreator<Props>): React.ReactElement {
   // The componentry util will: filter out remaining library props, create base
   // styles, and create base classNames
-  /* @ts-ignore BaseProps isn't fully typed out to match componentry() yet */
-  const { utilityCx, props, styles } = componentry(merged)
+  const { utilityCx, props, styles } = utilityStyles(merged)
 
   return createElement(as, {
     style: { ...styles, ...style },

--- a/src/utils/static-component-builder.tsx
+++ b/src/utils/static-component-builder.tsx
@@ -18,7 +18,7 @@ export function staticComponent<Props>(
   defaultProps?: StaticOptions<Props>,
 ): React.FC<Props> {
   function Component(props: Props) {
-    return element(displayName, {
+    return element({
       ...defaultProps,
       ...useTheme<Props>(displayName),
       ...props,

--- a/src/utils/style-utilities.ts
+++ b/src/utils/style-utilities.ts
@@ -111,7 +111,7 @@ type Props = {
   [prop: string]: unknown
 }
 
-type ComponentryAttributes = {
+type UtilityStyles = {
   props: Props
   styles: React.CSSProperties
   utilityCx: [UtilityClasses, string[]]
@@ -125,7 +125,7 @@ type ComponentryAttributes = {
  * NB: values are passed through without additional mapping, eg the number 1
  * isn't mapped to 1px or 1rem.
  */
-export function componentry({
+export function utilityStyles({
   /* eslint-disable @typescript-eslint/no-unused-vars */
   __precompile,
   block,
@@ -148,7 +148,7 @@ export function componentry({
   // ✓ Active props filtered out
   /* eslint-enable @typescript-eslint/no-unused-vars */
   ...filteredProps
-}: Props): ComponentryAttributes {
+}: Props): UtilityStyles {
   const classNames: UtilityProps = {}
   const spacingCx: string[] = []
   const styles: React.CSSProperties = {}


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Sumary

_Semantic update to use "Utilities" everywhere._

Closes #363 

### Notes

System props was aligning towards Styled System and MUI, but aligning with Tailwind is a higher priority and "Utility styles" is a more conventional name for these classses.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
