### PR TITLE
Fix: Default alert theme styles

### DIFF
--- a/src/components/Alert/Alert.stories.mdx
+++ b/src/components/Alert/Alert.stories.mdx
@@ -17,40 +17,21 @@ directly or the Alert can be nested inside of an Active component to automatical
 an uncontrolled Alert.
 
 <Canvas>
-  <Story
-    name='Colors'
-    decorators={[
-      (Story) => (
-        <div className='grid gap-2'>
-          <Story />
-        </div>
-      ),
-    ]}
-  >
+  <Story name='Alert'>
     <Alert color='primary'>
-      <Text>Primary themed alert</Text>
+      <Text variant='h3' className='🅲Alert-heading'>
+        Well done!
+      </Text>
+      <Text>You successfully read this important alert message.</Text>
+      <hr className='my-2' />
+      <Link href='#demo' className='🅲Alert-link'>
+        Go home
+      </Link>
     </Alert>
-    <Alert color='info'>Info themed alert</Alert>
-    <Alert color='success'>Success themed alert</Alert>
-    <Alert color='warning'>Warning themed alert</Alert>
-    <Alert color='error'>Error themed alert</Alert>
   </Story>
 </Canvas>
 
-## Alert elements
-
 Styles are also included for: `alert-heading`, `alert-link`, and `<hr />` elements.
-
-<Alert color='primary'>
-  <Text variant='h3' className='🅲Alert-heading'>
-    Well done!
-  </Text>
-  <Text>You successfully read this important alert message.</Text>
-  <hr className='my-2' />
-  <Link href='#demo' className='🅲Alert-link'>
-    Go home
-  </Link>
-</Alert>
 
 ## Dismissible
 

--- a/src/components/Alert/Alert.styles.ts
+++ b/src/components/Alert/Alert.styles.ts
@@ -17,9 +17,20 @@ export const Alert: Record<string, unknown> = {
 
   // VARIANTS
   '.🅲Alert-filled': {
-    padding: theme.spacing[2],
-    border: '1px solid transparent',
-    borderRadius: theme.borderRadius.md,
+    'padding': theme.spacing[2],
+    'background': theme.colors.primary[100],
+    'color': theme.colors.primary[500],
+    'border': '1px solid transparent',
+    'borderRadius': theme.borderRadius.md,
+    'borderColor': theme.colors.primary[300],
+
+    '& .🅲Alert-link': {
+      fontWeight: theme.fontWeight.bold,
+    },
+
+    '& hr': {
+      borderTopColor: theme.colors.primary[300],
+    },
   },
 
   // ELEMENTS
@@ -36,26 +47,28 @@ export const Alert: Record<string, unknown> = {
   '.🅲Alert-close': {
     flexShrink: 0,
     marginLeft: theme.spacing[1],
+    color: 'inherit',
   },
 }
 
 // --------------------------------------------------------
 // COLORS
 
-const themeColors = ['primary', 'info', 'success', 'warning', 'error'] as const
-themeColors.forEach((color) => {
-  Alert[`.🅲Alert-filled.🅲Alert-${color}Color`] = {
-    'background': theme.colors[color][100],
-    'borderColor': theme.colors[color][300],
-    'color': theme.colors[color][500],
+// Example of adding theme colors to an alert variant
+// const themeColors = ['info', 'success', 'warning', 'error'] as const
+// themeColors.forEach((color) => {
+//   Alert[`.🅲Alert-filled.🅲Alert-${color}Color`] = {
+//     'background': theme.colors[color][100],
+//     'borderColor': theme.colors[color][300],
+//     'color': theme.colors[color][500],
 
-    '& .🅲Alert-link': {
-      color: theme.colors[color][500],
-      fontWeight: theme.fontWeight.bold,
-    },
+//     '& .🅲Alert-link': {
+//       color: theme.colors[color][500],
+//       fontWeight: theme.fontWeight.bold,
+//     },
 
-    '& hr': {
-      borderTopColor: theme.colors[color][300],
-    },
-  }
-})
+//     '& hr': {
+//       borderTopColor: theme.colors[color][300],
+//     },
+//   }
+// })

--- a/src/components/Link/Link.styles.ts
+++ b/src/components/Link/Link.styles.ts
@@ -13,7 +13,7 @@ export const Link = {
   '.🅲Link-text': {
     'color': theme.colors.primary[500],
     '&:hover': {
-      color: theme.colors.primary[900],
+      color: theme.colors.primary[700],
     },
   },
 }


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Fixes a few small style issues in Alert_

### Notes

- Removes default theme colors for alert - currently these will throw an error if theme colors haven't been defined.
- Improves link styles - in and out of Alerts
