### PR TITLE
New: Convenience components rule

### DIFF
--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -1,20 +1,7 @@
 @tailwind base;
 
 @tailwind components;
-
-/* oh no - close styles order conflict with CloseBase */
-@componentry Close;
-
-@componentry Alert;
-@componentry Badge;
-@componentry Button;
-@componentry Card;
-@componentry Icon;
-@componentry Input;
-@componentry FormGroup;
-@componentry Link;
-@componentry Table;
-@componentry Text;
+@componentry components;
 
 .sbdocs-h2 {
   /* Storybook is setting this to 0 between stories, give them some space */

--- a/src/components/Close/Close.stories.mdx
+++ b/src/components/Close/Close.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
+import { ArgsTable, Meta, Story } from '@storybook/addon-docs'
 import { BADGE } from '@geometricpanda/storybook-addon-badges'
 
 import { Close } from './Close'
@@ -15,8 +15,6 @@ The Close component wraps an instance of Icon to create an accessible close elem
 the Alert and Modal components. The `🅲Close-base` class provides a target for custom
 styling when needed.
 
-<Canvas>
-  <Story name='Close'>
-    <Close onClick={console.log} />
-  </Story>
-</Canvas>
+<Story name='Close'>
+  <Close onClick={console.log} />
+</Story>

--- a/src/components/Close/Close.styles.ts
+++ b/src/components/Close/Close.styles.ts
@@ -1,24 +1,23 @@
-import { getMergedConfig } from '../../plugin-postcss/configs'
-
-const { theme } = getMergedConfig()
-
-//                                        <Button /> styles
+//                                        <Close /> styles
 // --------------------------------------------------------
 
-// Componentry supports using an SVG icon so that applications can choose a close
-// icon that fits their theme, as well as using flexbox on containers with close
-// buttons instead of floats.
-
-// The 🅲Close classes allows for targeted styles for the close buttons. The .icon-close
-// can also be styled for close buttons only using that as a target
-// ℹ️ The background image styles for close icons is located in `/styles/componentry/icons`
+// The 🅲Close-base class allows for targeted styles for close buttons. The
+// .icon-close can also be styled for SVG customizations.
+//
+// 📝 Close originally included a `color` and `fontSize` style, but due to
+// ordering these styles would override Alert close customizations so they were
+// removed to keep this element as flexible as possible. -> The intent is that
+// this building block will be used in other design system elements, and those
+// elements can customize size/color as needed
+//
+// ℹ️ The background image styles for close icons is located in the Icon styles
 export const Close = {
   '.🅲Close-base': {
     // Layout
     'alignItems': 'center',
     'display': 'inline-flex',
     'justifyContent': 'center',
-    'lineHeight': 1, // ensures text is center aligned within flex layout
+    'lineHeight': 1, // ensures icon is center aligned within flex layout
 
     // Button resets
     'appearance': 'none', // Remove Chrome native button styling
@@ -26,11 +25,7 @@ export const Close = {
     'backgroundColor': 'transparent',
     'border': 'none',
     'borderRadius': 0,
-
-    'color': theme.colors.gray[500],
-    'fontSize': theme.fontSize.base,
-
-    'userSelect': 'auto',
+    'userSelect': 'none',
 
     // Animate close icon opacity on hover
     'opacity': 0.6,


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Adds a new rollup style option_

### Notes

Provides a `@componentry components;` rollup option for including all component styles. This is a convenience option if you're using all of the components.

Closes #382 

<!-- Thank you for contributing, you are AWESOME 🥳 -->
