### PR TITLE
New: Expose utilityClasses fn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,4 @@ export { Tooltip } from './components/Tooltip/Tooltip'
 // --- Utilities
 export { useActive, useActiveScrollReset, useNoScroll, useVisible } from './hooks'
 export { setupOutlineHandlers } from './utils/dom'
+export { utilityClasses } from './utils/utility-classes'

--- a/src/utils/utility-classes.ts
+++ b/src/utils/utility-classes.ts
@@ -126,13 +126,20 @@ function generateClassNames<Props extends DefaultUtilityProps>(
 }
 
 /**
- * utilityClasses filters out Componentry component and utility props, returning
- * a set of utility styles and final passthrough props for underlying component
- * elements.
+ * `utilityClasses` filters and transforms the Componentry utility props into
+ * utility styles.
+ *
+ * *IMPORTANT* - the returned `utilityCx` must be evaluated by a className
+ * generator like `clsx` or `classnames` before it can be used as a `className`
+ * prop value.
+ * @example
+ * const { passThroughProps, utilityCx } = utilityClasses(props)
+ * return (
+ *   <div className={clsx(utilityCX)} {...passThroughProps}>{children}</div>
+ * )
  */
 export function utilityClasses({
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  __precompile,
   block,
   outline,
   fill,
@@ -141,6 +148,7 @@ export function utilityClasses({
   pills,
   variant,
   vertical,
+  __precompile,
   // ✓ Componentry props filtered out
   activate,
   deactivate,


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Exposes `utilityClasses`_

### Notes

Enables users to create their own custom design system components with support for the standard utility props.

Closes #383 
