### PR TITLE
Update: Replace __precompile prop

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,7 +3,7 @@
 /* eslint-disable import/extensions */
 
 module.exports = {
-  // Base configsa are used by ESLint babel parser
+  // Base configs are used by ESLint babel parser
   presets: ['@babel/preset-react', '@babel/preset-typescript'],
 
   env: {

--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -13,7 +13,7 @@ export interface BlockProps extends ComponentBaseProps<'div'> {
  */
 export const Block: React.FC<BlockProps> = (props) => {
   const { inline, ...rest } = {
-    ...useTheme<BlockProps>('Block', props.__precompile),
+    ...useTheme<BlockProps>('Block'),
     ...props,
   }
 

--- a/src/components/Card/Card.ts
+++ b/src/components/Card/Card.ts
@@ -44,7 +44,7 @@ export interface Card {
  */
 export const Card = ((props) => {
   const { variant = 'outlined', ...rest } = {
-    ...useTheme<CardProps>('Card', props.__precompile),
+    ...useTheme<CardProps>('Card'),
     ...props,
   }
 

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -21,7 +21,7 @@ export interface FlexProps extends ComponentBaseProps<'div'> {
  */
 export const Flex: React.FC<FlexProps> = (props) => {
   const { align, direction, inline, justify, wrap, ...rest } = {
-    ...useTheme<FlexProps>('Flex', props.__precompile),
+    ...useTheme<FlexProps>('Flex'),
     ...props,
   }
   // Tailwind uses a flex-col class but direction="col" is super wonky

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -19,7 +19,7 @@ export interface GridProps extends ComponentBaseProps<'div'> {
  */
 export const Grid: React.FC<GridProps> = (props) => {
   const { align, gap, inline, justify, ...rest } = {
-    ...useTheme<GridProps>('Grid', props.__precompile),
+    ...useTheme<GridProps>('Grid'),
     ...props,
   }
 

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -37,7 +37,7 @@ export const Text: React.FC<Props> = (props) => {
     bold,
     ...rest
   } = {
-    ...useTheme<Props & { elementsMap?: ElementsMap }>('Text', props.__precompile),
+    ...useTheme<Props & { elementsMap?: ElementsMap }>('Text'),
     ...props,
   }
 

--- a/src/components/Theme/Theme.tsx
+++ b/src/components/Theme/Theme.tsx
@@ -17,17 +17,7 @@ export const Theme: React.FC<ThemeProps> = ({ children, theme }) => {
 }
 Theme.displayName = 'Theme'
 
-/**
- * [Theme hook 📝](https://componentry.design/components/theme)
- * @param componentName Library component name, eg Button, Dropdown, Modal, etc.
- */
-export function useTheme<Theme>(componentName: string, __precompile = false): Theme {
-  // @ts-ignore DEBT: not sure how to type
-  if (__precompile) return {}
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- Library __precompile is a build time constant
-  const theme = useContext(ThemeCtx)
-
+function getThemeValue(theme: any, componentName: string | undefined) {
   // For the theme context, we don't warn on accessing without a provider b/c
   // internally components use this hook to check for optionally set theme
   // values in apps where the provider may not have been added.
@@ -40,4 +30,31 @@ export function useTheme<Theme>(componentName: string, __precompile = false): Th
 
   // @ts-ignore DEBT: not sure how to type
   return componentName in theme ? theme[componentName] : {}
+}
+
+let preCompileMode = false
+let preCompileThemeValue = {}
+
+export function initializePreCompileMode(theme: any) {
+  preCompileMode = true
+  preCompileThemeValue = theme
+}
+
+function useContextTheme(componentName: string) {
+  const theme = useContext(ThemeCtx)
+  return getThemeValue(theme, componentName)
+}
+
+/**
+ * [Theme hook 📝](https://componentry.design/components/theme)
+ * @param componentName Library component name, eg Button, Dropdown, Modal, etc.
+ */
+export function useTheme<Theme>(componentName: string): Theme {
+  if (preCompileMode) {
+    return getThemeValue(preCompileThemeValue, componentName)
+  }
+  // During Babel pre-compiling `preCompileMode` will always be true, during
+  // runtime execution it will always be false
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useContextTheme(componentName)
 }

--- a/src/plugin-babel/parse-attributes.ts
+++ b/src/plugin-babel/parse-attributes.ts
@@ -18,9 +18,7 @@ export function parseAttributes(
 } {
   let parseSuccess = true
   const passThroughAttributes: t.JSXAttribute[] = []
-  const parsedAttributes: Record<string, string | number | boolean> = {
-    __precompile: true,
-  }
+  const parsedAttributes: Record<string, string | number | boolean> = {}
 
   attributes.forEach((attribute) => {
     // We can't tell what is in spread attributes, eg {...rest}, so bail if one is found

--- a/src/plugin-babel/plugin.ts
+++ b/src/plugin-babel/plugin.ts
@@ -4,6 +4,7 @@ import { PluginObj, types } from '@babel/core'
 import { Flex } from '../components/Flex/Flex'
 import { Block } from '../components/Block/Block'
 import { Text } from '../components/Text/Text'
+import { initializePreCompileMode } from '../components/Theme/Theme'
 import { precompileProps, utilityProps } from '../utils/utility-classes'
 
 import { parseAttributes } from './parse-attributes'
@@ -46,6 +47,7 @@ type BabelObj = { types: Types }
  * Componentry precompile Babel plugin
  */
 const componentryPlugin = ({ types: t }: BabelObj): PluginObj<VisitorState> => {
+  initializePreCompileMode({}) // TODO: Accept theme through options
   return {
     name: 'componentry-plugin',
     visitor: {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -143,8 +143,6 @@ export type ComponentBaseProps<Element extends React.ElementType> = {
   as?: React.ElementType
   /** Component className, can be a string, array, or object */
   className?: ClassValue
-  /** Internal flag for switching between runtime and precompile modes */
-  __precompile?: boolean
 } & MergePropTypes<DefaultUtilityProps, UtilityProps> &
   Omit<React.ComponentPropsWithoutRef<Element>, 'className'>
 

--- a/src/utils/utility-classes.ts
+++ b/src/utils/utility-classes.ts
@@ -148,7 +148,6 @@ export function utilityClasses({
   pills,
   variant,
   vertical,
-  __precompile,
   // ✓ Componentry props filtered out
   activate,
   deactivate,


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Replaces mechanism for skipping theme context during Babel pre-compilation._

### Notes

- The `__precompile` prop that had to be passed for each component was not "elegant" and could be confusing for package users.
- Updated mechanism allows for notifying the theme module during pre-compiling to skip using React context

<!-- Thank you for contributing, you are AWESOME 🥳 -->
