### PR TITLE
Update: Expose correct utility types

### DIFF
--- a/src/components/Active/Active.ts
+++ b/src/components/Active/Active.ts
@@ -2,10 +2,10 @@ import { activeContainerBuilder } from '../../utils/active-container-component-b
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  ActiveActionBaseProps,
-  ActiveContainerBaseProps,
-  ActiveContentBaseProps,
-  ComponentBaseProps,
+  type ActiveActionBaseProps,
+  type ActiveContainerBaseProps,
+  type ActiveContentBaseProps,
+  type ComponentBaseProps,
 } from '../../utils/types'
 import { Link } from '../Link/Link'
 

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import { closeBase } from '../Close/Close'
 import { useTheme } from '../Theme/Theme'
 import { useActive, useVisible } from '../../hooks'
-import { ComponentBaseProps, MergePropTypes } from '../../utils/types'
+import { type ComponentBaseProps, type MergePropTypes } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
 
 // Module augmentation interface for overriding component props' types
-export interface AlertProps {}
+export interface AlertPropsOverrides {}
 
-interface DefaultAlertProps {
+interface AlertPropsDefaults {
   /** Sets a custom aria title */
   ariaTitle?: string
   /** Sets the theme color of the alert */
@@ -30,12 +30,13 @@ interface DefaultAlertProps {
   variant?: 'filled'
 }
 
-type Props = MergePropTypes<DefaultAlertProps, AlertProps> & ComponentBaseProps<'div'>
+type AlertProps = MergePropTypes<AlertPropsDefaults, AlertPropsOverrides> &
+  ComponentBaseProps<'div'>
 
 interface AlertCloseProps extends ComponentBaseProps<'button'> {}
 
 interface Alert {
-  (props: Props): React.ReactElement | null
+  (props: AlertProps): React.ReactElement | null
   displayName: 'Alert'
   /**
    * [Alert close component 📝](https://componentry.design/components/alert)

--- a/src/components/Badge/Badge.ts
+++ b/src/components/Badge/Badge.ts
@@ -1,6 +1,6 @@
 import { useTheme } from '../Theme/Theme'
 import { element } from '../../utils/element-creator'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 
 interface BadgeProps extends ComponentBaseProps<'div'> {
   /** Variant color */

--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
 export interface BlockProps extends ComponentBaseProps<'div'> {

--- a/src/components/Button/Button.ts
+++ b/src/components/Button/Button.ts
@@ -1,12 +1,12 @@
 import { forwardRef } from 'react'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps, MergePropTypes } from '../../utils/types'
+import { type ComponentBaseProps, type MergePropTypes } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
 // Module augmentation interface for overriding component props' types
-export interface ButtonProps {}
+export interface ButtonPropsOverrides {}
 
-interface DefaultButtonProps {
+interface ButtonPropsDefaults {
   /** Button variant color */
   color?: 'primary'
   /** Disables the element, preventing mouse and keyboard events */
@@ -21,14 +21,14 @@ interface DefaultButtonProps {
   variant?: 'filled' | 'outlined'
 }
 
-type Props = MergePropTypes<DefaultButtonProps, ButtonProps> &
+type ButtonProps = MergePropTypes<ButtonPropsDefaults, ButtonPropsOverrides> &
   ComponentBaseProps<'button'>
 
 /**
  * [Button component 📝](https://componentry.design/components/button)
  * @experimental
  */
-export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
   const {
     variant = 'filled',
     color,

--- a/src/components/Card/Card.ts
+++ b/src/components/Card/Card.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import { useTheme } from '../Theme/Theme'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 
 interface CardProps extends ComponentBaseProps<'div'> {
   variant?: 'outlined'

--- a/src/components/Close/Close.tsx
+++ b/src/components/Close/Close.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { type ClassValue } from 'clsx'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { staticComponent } from '../../utils/static-component-builder'
 import { Icon } from '../Icon/Icon'
 

--- a/src/components/Drawer/Drawer.ts
+++ b/src/components/Drawer/Drawer.ts
@@ -2,10 +2,10 @@ import { activeContainerBuilder } from '../../utils/active-container-component-b
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  ActiveActionBaseProps,
-  ActiveContainerBaseProps,
-  ActiveContentBaseProps,
-  ComponentBaseProps,
+  type ActiveActionBaseProps,
+  type ActiveContainerBaseProps,
+  type ActiveContentBaseProps,
+  type ComponentBaseProps,
 } from '../../utils/types'
 import { Link } from '../Link/Link'
 

--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -2,10 +2,10 @@ import { activeContainerBuilder } from '../../utils/active-container-component-b
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  ActiveActionBaseProps,
-  ActiveContainerBaseProps,
-  ActiveContentBaseProps,
-  ComponentBaseProps,
+  type ActiveActionBaseProps,
+  type ActiveContainerBaseProps,
+  type ActiveContentBaseProps,
+  type ComponentBaseProps,
 } from '../../utils/types'
 import { Button } from '../Button/Button'
 

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
 export interface FlexProps extends ComponentBaseProps<'div'> {

--- a/src/components/FormGroup/FormGroup.ts
+++ b/src/components/FormGroup/FormGroup.ts
@@ -1,4 +1,4 @@
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { staticComponent } from '../../utils/static-component-builder'
 
 export interface FormGroupProps extends ComponentBaseProps<'div'> {}

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
 export interface GridProps extends ComponentBaseProps<'div'> {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps, MergePropTypes } from '../../utils/types'
+import { type ComponentBaseProps, type MergePropTypes } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
 // Module augmentation interface for overriding component props' types
-export interface IconProps {}
+export interface IconPropsOverrides {}
 
-interface DefaultIconProps {
+interface IconPropsDefaults {
   /** Adjusts the text baseline using a negative margin, this can be used to align font icons outside of flex containers */
   baseline?: boolean
   /** SVG id for href link */
@@ -15,18 +15,19 @@ interface DefaultIconProps {
   variant?: 'font'
 }
 
-type Props = MergePropTypes<DefaultIconProps, IconProps> & ComponentBaseProps<'svg'>
+type IconProps = MergePropTypes<IconPropsDefaults, IconPropsOverrides> &
+  ComponentBaseProps<'svg'>
 
 /**
  * [Icon component 📝](https://componentry.design/components/icon)
  */
-export const Icon: React.FC<Props> = (props) => {
+export const Icon: React.FC<IconProps> = (props) => {
   const {
     baseline,
     variant = 'font',
     id,
     ...rest
-  } = { ...useTheme<Props>('Icon'), ...props }
+  } = { ...useTheme<IconProps>('Icon'), ...props }
 
   return element({
     as: 'svg',

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useRef } from 'react'
 import { nanoid } from 'nanoid'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
 

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
 interface LinkProps extends ComponentBaseProps<'a'> {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,7 +5,7 @@ import { nanoid } from 'nanoid'
 import { closeBase } from '../Close/Close'
 import { useTheme } from '../Theme/Theme'
 import { useActive, useActiveScrollReset, useNoScroll, useVisible } from '../../hooks'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -6,10 +6,10 @@ import { activeActionBuilder } from '../../utils/active-action-component-builder
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import { staticComponent } from '../../utils/static-component-builder'
 import {
-  ActiveActionBaseProps,
-  ActiveContainerBaseProps,
-  ActiveContentBaseProps,
-  ComponentBaseProps,
+  type ActiveActionBaseProps,
+  type ActiveContainerBaseProps,
+  type ActiveContentBaseProps,
+  type ComponentBaseProps,
 } from '../../utils/types'
 
 export interface PopoverProps

--- a/src/components/Table/Table.ts
+++ b/src/components/Table/Table.ts
@@ -1,5 +1,5 @@
 import { staticComponent } from '../../utils/static-component-builder'
-import { ComponentBaseProps } from '../../utils/types'
+import { type ComponentBaseProps } from '../../utils/types'
 
 export interface TableProps extends ComponentBaseProps<'div'> {}
 export interface TableBodyProps extends ComponentBaseProps<'div'> {}

--- a/src/components/Tabs/Tabs.ts
+++ b/src/components/Tabs/Tabs.ts
@@ -3,10 +3,10 @@ import { activeContainerBuilder } from '../../utils/active-container-component-b
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  ActiveActionBaseProps,
-  ActiveContainerBaseProps,
-  ActiveContentBaseProps,
-  ComponentBaseProps,
+  type ActiveActionBaseProps,
+  type ActiveContainerBaseProps,
+  type ActiveContentBaseProps,
+  type ComponentBaseProps,
 } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTheme } from '../Theme/Theme'
-import { ComponentBaseProps, MergePropTypes } from '../../utils/types'
+import { type ComponentBaseProps, type MergePropTypes } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
 /** Element used for each variant */
@@ -16,28 +16,29 @@ const defaultElementsMap: ElementsMap = {
 }
 
 // Module augmentation interface for overriding component props' types
-export interface TextProps {}
+export interface TextPropsOverrides {}
 
-interface DefaultTextProps {
+interface TextPropsDefaults {
   /** Display variant */
   variant?: 'h1' | 'h2' | 'h3' | 'body' | 'code' | 'small'
   /** Sets a bold font-weight style */
   bold?: boolean
 }
 
-type Props = MergePropTypes<DefaultTextProps, TextProps> & ComponentBaseProps<'div'>
+type TextProps = MergePropTypes<TextPropsDefaults, TextPropsOverrides> &
+  ComponentBaseProps<'div'>
 
 /**
  * [Text component 📝](https://componentry.design/components/text)
  */
-export const Text: React.FC<Props> = (props) => {
+export const Text: React.FC<TextProps> = (props) => {
   const {
     variant = 'body',
     elementsMap = defaultElementsMap,
     bold,
     ...rest
   } = {
-    ...useTheme<Props & { elementsMap?: ElementsMap }>('Text'),
+    ...useTheme<TextProps & { elementsMap?: ElementsMap }>('Text'),
     ...props,
   }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,14 +4,14 @@
  */
 
 import {
-  RefObject,
+  type RefObject,
   useContext,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
 } from 'react'
-import { ActiveContext, ActiveCtx } from './utils/active-container-component-builder'
+import { type ActiveContext, ActiveCtx } from './utils/active-container-component-builder'
 
 // --------------------------------------------------------
 // useActive hook

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,11 @@ export { Modal } from './components/Modal/Modal'
 export { Popover } from './components/Popover/Popover'
 export { Table } from './components/Table/Table'
 export { Tabs } from './components/Tabs/Tabs'
-export { Text, Text as Typography } from './components/Text/Text'
+export { Text } from './components/Text/Text'
 export { Tooltip } from './components/Tooltip/Tooltip'
 
 // --- Utilities
 export { useActive, useActiveScrollReset, useNoScroll, useVisible } from './hooks'
 export { setupOutlineHandlers } from './utils/dom'
 export { utilityClasses } from './utils/utility-classes'
+export { type UtilityProps } from './utils/types'

--- a/src/utils/active-action-component-builder.tsx
+++ b/src/utils/active-action-component-builder.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
 import { useTheme } from '../components/Theme/Theme'
 import { ActiveCtx } from './active-container-component-builder'
-import { ARIAControls, computeARIA } from './aria'
-import { ActiveActionBaseProps } from './types'
+import { type ARIAControls, computeARIA } from './aria'
+import { type ActiveActionBaseProps } from './types'
 import { element } from './element-creator'
 
 interface ActiveActionBuilder {

--- a/src/utils/active-container-component-builder.tsx
+++ b/src/utils/active-container-component-builder.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useCallback, useEffect, useRef, useState } from 'react'
 import { nanoid } from 'nanoid'
 import { useTheme } from '../components/Theme/Theme'
-import { ActiveContainerBaseProps } from './types'
+import { type ActiveContainerBaseProps } from './types'
 import { closest } from './dom'
 import { element } from './element-creator'
 

--- a/src/utils/active-content-component-builder.tsx
+++ b/src/utils/active-content-component-builder.tsx
@@ -2,8 +2,8 @@ import React, { useContext } from 'react'
 import { useTheme } from '../components/Theme/Theme'
 import { useVisible } from '../hooks'
 import { ActiveCtx } from './active-container-component-builder'
-import { ARIAControls, computeARIA } from './aria'
-import { ActiveContentBaseProps } from './types'
+import { type ARIAControls, computeARIA } from './aria'
+import { type ActiveContentBaseProps } from './types'
 import { element } from './element-creator'
 
 interface ActiveContentBuilder {

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import { AriaAttributes } from 'react'
+import { type AriaAttributes } from 'react'
 
 type StringBoolean = 'true' | 'false'
 

--- a/src/utils/element-creator.tsx
+++ b/src/utils/element-creator.tsx
@@ -1,7 +1,7 @@
 import React, { createElement } from 'react'
 import clsx, { type ClassValue } from 'clsx'
 import { utilityClasses } from './utility-classes'
-import { DefaultUtilityProps } from './types'
+import { UtilityProps } from './types'
 
 /**
  * ElementProps includes the shared props _including internal componentCx prop_
@@ -12,7 +12,7 @@ type ElementProps = {
   className?: ClassValue
   componentCx?: ClassValue
   themeCx?: ClassValue
-} & DefaultUtilityProps
+} & UtilityProps
 
 /**
  * element de-duplicates component code for merging classNames and providing a

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,9 @@
-import React from 'react'
+import {
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  type MouseEvent,
+  type ReactNode,
+} from 'react'
 import { type ClassValue } from 'clsx'
 
 /**
@@ -15,12 +20,12 @@ export type MergePropTypes<Defaults, Overrides> = {
 }
 
 // Module augmentation interface for overriding utility props' types
-export interface UtilityProps {}
+export interface UtilityPropsOverrides {}
 
 /**
  * Componentry shared utility props for using utility styles
  */
-export interface DefaultUtilityProps {
+interface UtilityPropsDefaults {
   /** Sets active style */
   active?: boolean | string
   /** Sets align-content style */
@@ -134,27 +139,29 @@ export interface DefaultUtilityProps {
   py?: string | number
 }
 
+export type UtilityProps = MergePropTypes<UtilityPropsDefaults, UtilityPropsOverrides>
+
 /**
  * Base props supported by all Componentry components. Includes the utility
  * styles props and the HTML attributes for the element DOM type.
  */
-export type ComponentBaseProps<Element extends React.ElementType> = {
+export type ComponentBaseProps<Element extends ElementType> = {
   /** Component element */
-  as?: React.ElementType
+  as?: ElementType
   /** Component className, can be a string, array, or object */
   className?: ClassValue
-} & MergePropTypes<DefaultUtilityProps, UtilityProps> &
-  Omit<React.ComponentPropsWithoutRef<Element>, 'className'>
+} & UtilityProps &
+  Omit<ComponentPropsWithoutRef<Element>, 'className'>
 
 // --------------------------------------------------------
 // Active components
 
 export interface ActiveContainerBaseProps {
   /** Container children */
-  children?: React.ReactNode
+  children?: ReactNode
 
   /** Component element */
-  as?: React.ElementType
+  as?: ElementType
 
   /** Sets a container content placement direction className */
   direction?: 'top' | 'left' | 'right' | 'bottom'
@@ -166,35 +173,35 @@ export interface ActiveContainerBaseProps {
   /** Starting active state */
   defaultActive?: boolean | string
   /** Called to handle activate event */
-  activate?: (event: React.MouseEvent<HTMLElement>) => void
+  activate?: (event: MouseEvent<HTMLElement>) => void
   /** Called to handle deactivate event */
-  deactivate?: (event: React.MouseEvent<HTMLElement>) => void
+  deactivate?: (event: MouseEvent<HTMLElement>) => void
   /** Called before activate event */
-  onActivate?: (event: React.MouseEvent<HTMLElement>) => void
+  onActivate?: (event: MouseEvent<HTMLElement>) => void
   /** Called after activate event */
-  onActivated?: (event: React.MouseEvent<HTMLElement>) => void
+  onActivated?: (event: MouseEvent<HTMLElement>) => void
   /** Called before deactivate event */
-  onDeactivate?: (event: React.MouseEvent<HTMLElement>) => void
+  onDeactivate?: (event: MouseEvent<HTMLElement>) => void
   /** Called after deactivate event */
-  onDeactivated?: (event: React.MouseEvent<HTMLElement>) => void
+  onDeactivated?: (event: MouseEvent<HTMLElement>) => void
 }
 
 export interface ActiveActionBaseProps {
   /** Component element */
-  as?: React.ElementType
+  as?: ElementType
   /** Action/Content pairing id for compound active components */
   activeId?: string
   /** Component children */
-  children?: React.ReactNode
+  children?: ReactNode
 }
 
 export interface ActiveContentBaseProps {
   /** Component element */
-  as?: React.ElementType
+  as?: ElementType
   /** Action/Content pairing id for compound active components */
   activeId?: string
   /** Component children */
-  children?: React.ReactNode
+  children?: ReactNode
   /**
    * Controls when the component content is mounted where:
    * - `'always'` - The content will be mounted when the element is both visible

--- a/src/utils/utility-classes.ts
+++ b/src/utils/utility-classes.ts
@@ -1,5 +1,5 @@
 import { type ClassDictionary } from 'clsx'
-import { DefaultUtilityProps } from './types'
+import { type UtilityProps } from './types'
 
 export const utilityProps = {
   'active': 1,
@@ -53,9 +53,7 @@ export const utilityProps = {
   'width': 1,
 }
 
-function generateClassNames<Props extends DefaultUtilityProps>(
-  p: Props,
-): ClassDictionary {
+function generateClassNames<Props extends UtilityProps>(p: Props): ClassDictionary {
   return {
     // LAYOUT
     [p.position ?? 'position']: p.position,
@@ -160,7 +158,7 @@ export function utilityClasses({
   // ✓ Active props filtered out
   /* eslint-enable @typescript-eslint/no-unused-vars */
   ...filteredProps
-}: ComponentProps & DefaultUtilityProps) {
+}: ComponentProps & UtilityProps) {
   const passThroughProps: ComponentProps = {}
 
   // Pass through disabled to final element as it's a valid HTML attribute


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Updates the exposed types from the library to enable creating custom components with `utilityStyles`._

### Notes

Closes #387 

- Module augmentation exports now include "overrides" in their name for explicitness
- Merged utility types type is exported for use with `utilityStyles`
- Updated imports to use `type <TYPE>` syntax for clarity
