### PR TITLE
Fix: Compiler error of 'cannot be named'

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -25,7 +25,7 @@ export interface UtilityPropsOverrides {}
 /**
  * Componentry shared utility props for using utility styles
  */
-interface UtilityPropsDefaults {
+export interface UtilityPropsDefaults {
   /** Sets active style */
   active?: boolean | string
   /** Sets align-content style */


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

Fixes this compiler error:

```
Exported variable 'Button' has or is using name 'UtilityPropsDefaults' from external module "/componentry/src/utils/types" but cannot be named.
```


