### PR TITLE
Fix: Compilation configs polyfill fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "componentry",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "componentry",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.17",
@@ -1948,9 +1948,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz",
-      "integrity": "sha512-3fKhuICS1lMz0plI5ktOE/yEtBRMVxplzRkdn6mJQ197XiY0JnrzYV0+Mxozq3JZ8SBV9Ecurmw1XsGbwOf+Sg==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.2.tgz",
+      "integrity": "sha512-NcKtr2epxfIrNM4VOmPKO46TvDMCBhgi2CrSHaEarrz+Plk2K5r9QemmOFTGpZaoKnWoGH5MO+CzeRsih/Fcgg==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.20.2",
@@ -32575,9 +32575,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz",
-      "integrity": "sha512-3fKhuICS1lMz0plI5ktOE/yEtBRMVxplzRkdn6mJQ197XiY0JnrzYV0+Mxozq3JZ8SBV9Ecurmw1XsGbwOf+Sg==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.2.tgz",
+      "integrity": "sha512-NcKtr2epxfIrNM4VOmPKO46TvDMCBhgi2CrSHaEarrz+Plk2K5r9QemmOFTGpZaoKnWoGH5MO+CzeRsih/Fcgg==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "4.0.0-beta.3",
   "description": "React component library for building custom design systems",
   "sideEffects": false,
-  "types": "types/index.d.ts",
   "exports": {
     "browser": "./dist/browser/index.js",
     "node": {
       "module": "./dist/browser/index.js",
-      "require": "./dist/commonjs/index.cjs"
+      "require": "./dist/commonjs/index.js"
     },
     "default": "./dist/browser/index.js"
   },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/browser/index.js",
+  "types": "./types/index.d.ts",
   "keywords": [
     "accessibility",
     "components-library",


### PR DESCRIPTION
After some research it seems that most libraries do not include polyfills from Babel+core-js in their outputs. PR removes the corejs configs from Babel to fix broken build.
