### PR TITLE
Upgrade: Add dedicated setup mechanism for elements

### DIFF
--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -13,6 +13,13 @@
 @componentry components;
 @tailwind components;
 
+// Normally this would be an override in theme, but we don't have a theme for this
+// Storybook for simplicity -> Feather icons use stroke, not fill.
+.🅲Icon-font {
+  fill: none;
+  stroke: currentColor;
+}
+
 .sbdocs-h2 {
   /* Storybook is setting this to 0 between stories, give them some space */
   margin-top: 20px !important;

--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -13,8 +13,8 @@
 @componentry components;
 @tailwind components;
 
-// Normally this would be an override in theme, but we don't have a theme for this
-// Storybook for simplicity -> Feather icons use stroke, not fill.
+/* Normally this would be an override in theme, but we don't have a theme for this
+ Storybook for simplicity -> Feather icons use stroke, not fill. */
 .🅲Icon-font {
   fill: none;
   stroke: currentColor;

--- a/src/components/Icon/Icon.spec.js
+++ b/src/components/Icon/Icon.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 
 import { elementTests } from '../../test/element-tests'
-import { Icon } from './Icon'
+import { Icon, configureIconElementsMap } from './Icon'
 
 describe('<Icon />', () => {
   elementTests(Icon)
@@ -15,5 +15,24 @@ describe('<Icon /> snapshots', () => {
     render(<Icon id='test' data-testid='icon' />)
 
     expect(screen.getByTestId('icon')).toMatchSnapshot()
+  })
+})
+
+// --------------------------------------------------------
+// Configuration
+
+describe('Text', () => {
+  it('configureIconElementsMap allows configuring icon render elements', () => {
+    configureIconElementsMap({
+      test: () => (
+        <svg>
+          <path data-testid='test-el' />
+        </svg>
+      ),
+    })
+
+    render(<Icon id='test' />)
+
+    expect(screen.getByTestId('test-el')).toBeInTheDocument()
   })
 })

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -46,6 +46,20 @@ export const Icon: React.FC<IconProps> = (props) => {
 }
 Icon.displayName = 'Icon'
 
-export function configureIconElementsMap(newIconElementsMap: ElementsMap) {
-  iconElementsMap = newIconElementsMap
+/**
+ * Configuration method for defining the elements to render for each Icon ID.
+ * @remarks
+ * Configuring an icon elements map isn't necessary if you've setup an SVG
+ * symbol sprite.
+ * @example
+ * import Info from './info.svg'
+ * import Coffee from './coffee.svg'
+ *
+ * configureIconElementsMap({
+ *   info: Info,
+ *   coffee: Coffee
+ * })
+ */
+export function configureIconElementsMap(elementsMap: ElementsMap) {
+  iconElementsMap = elementsMap
 }

--- a/src/components/Text/Text.spec.js
+++ b/src/components/Text/Text.spec.js
@@ -1,27 +1,12 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 
-import { Theme } from '../Theme/Theme'
 import { elementTests } from '../../test/element-tests'
-import { Text } from './Text'
+import { Text, configureTextElementsMap } from './Text'
 
 describe('<Text/>', () => {
   // Basic library element test suite
   elementTests(Text)
-})
-
-describe('Text', () => {
-  it('When elementsMap is set in theme, then map is used for Text', () => {
-    render(
-      <Theme theme={{ Text: { elementsMap: { rad: 'section' } } }}>
-        <Text variant='rad'>Componentry</Text>
-      </Theme>,
-    )
-
-    expect(screen.getByText('Componentry')).toContainHTML(
-      '<section class="🅲Text-base 🅲Text-rad">Componentry</section>',
-    )
-  })
 })
 
 // Snapshots
@@ -31,5 +16,22 @@ describe('<Text /> snapshots', () => {
     render(<Text>Componentry</Text>)
 
     expect(screen.getByText('Componentry')).toMatchSnapshot()
+  })
+})
+
+// --------------------------------------------------------
+// Configuration
+
+describe('Text', () => {
+  it('configureTextElementsMap allows configuring variant render elements', () => {
+    configureTextElementsMap({
+      rad: 'section',
+    })
+
+    render(<Text variant='rad'>Componentry</Text>)
+
+    expect(screen.getByText('Componentry')).toContainHTML(
+      '<section class="🅲Text-base 🅲Text-rad">Componentry</section>',
+    )
   })
 })

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -4,18 +4,6 @@ import { type ComponentBaseProps } from '../../utils/base-types'
 import { type MergePropTypes } from '../../utils/types'
 import { element } from '../../utils/element-creator'
 
-/** Element used for each variant */
-type ElementsMap = Record<string, keyof JSX.IntrinsicElements>
-
-const defaultElementsMap: ElementsMap = {
-  h1: 'h1',
-  h2: 'h2',
-  h3: 'h3',
-  body: 'p',
-  code: 'code', // TODO: make a component?
-  small: 'small',
-}
-
 // Module augmentation interface for overriding component props' types
 export interface TextPropsOverrides {}
 
@@ -27,23 +15,50 @@ interface TextPropsDefaults {
 type TextProps = MergePropTypes<TextPropsDefaults, TextPropsOverrides> &
   ComponentBaseProps<'div'>
 
+type ElementsMap = {
+  [Variant: string]: keyof JSX.IntrinsicElements | (() => JSX.Element)
+}
+let textElementMap: ElementsMap = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  body: 'p',
+  code: 'code', // TODO: make a component?
+  small: 'small',
+}
+
 /**
  * [Text component 📝](https://componentry.design/components/text)
  */
 export const Text: React.FC<TextProps> = (props) => {
-  const {
-    variant = 'body',
-    elementsMap = defaultElementsMap,
-    ...rest
-  } = {
-    ...useTheme<TextProps & { elementsMap?: ElementsMap }>('Text'),
+  const { variant = 'body', ...rest } = {
+    ...useTheme<TextProps>('Text'),
     ...props,
   }
 
   return element({
-    as: elementsMap[variant],
+    as: textElementMap[variant],
     componentCx: `🅲Text-base 🅲Text-${variant}`,
     ...rest,
   })
 }
 Text.displayName = 'Text'
+
+/**
+ * Configuration method for defining the elements to render for each text
+ * variant.
+ * @remarks
+ * When used the initial elements are overridden, so be sure to define a
+ * complete mapping.
+ * @example
+ * configureTextElementsMap({
+ *   h1: 'h1',
+ *   h2: 'h2',
+ *   h3: 'h3',
+ *   subtitle: 'h4',
+ *   body: 'div',
+ * })
+ */
+export function configureTextElementsMap(elementsMap: ElementsMap) {
+  textElementMap = elementsMap
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export { Modal } from './components/Modal/Modal'
 export { Popover } from './components/Popover/Popover'
 export { Table } from './components/Table/Table'
 export { Tabs } from './components/Tabs/Tabs'
-export { Text } from './components/Text/Text'
+export { Text, configureTextElementsMap } from './components/Text/Text'
 export { Tooltip } from './components/Tooltip/Tooltip'
 
 // --- Utilities


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Upgrade to provide a consistent element setup for Icon and Text_

### Notes

- Both components export a "configure elements map" function that can be called during library setup from anywhere to define the map of elements to render for each variant/id.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
