### PR TITLE
Use simpler default prefix for library classes

### DIFF
--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -15,7 +15,7 @@
 
 /* Normally this would be an override in theme, but we don't have a theme for this
  Storybook for simplicity -> Feather icons use stroke, not fill. */
-.🅲Icon-font {
+.C9Y-Icon-font {
   fill: none;
   stroke: currentColor;
 }

--- a/docs/adr/02-classes.md
+++ b/docs/adr/02-classes.md
@@ -11,7 +11,7 @@ library needs to balance brevity with specificity with configurability.
 
 - The end result classNames should be readable and look "good".
 - Ideally the library avoids extra string manipulation if possible, eg changing
-  `size="small"` to `🅲Button-sizeSmall` requires upper-casing first letter,
+  `size="small"` to `C9Y-Button-sizeSmall` requires upper-casing first letter,
   adding code and execution overhead.
 - User style configuration is easier with camelCase b/c the styles are defined
   in JS.
@@ -25,28 +25,28 @@ library needs to balance brevity with specificity with configurability.
 
 ## Decision Outcome
 
-Component classes are prefixed with `🅲Component`, variants don't have a suffix,
-modifier classes have suffixes, eg for a Button, variant filled, error color,
-and small size:
+Component classes are prefixed with `C9Y-Component`, variants don't have a
+suffix, modifier classes have suffixes, eg for a Button, variant filled, error
+color, and small size:
 
 ```html
 <button
-  className="🅲Button-base 🅲Button-filled 🅲Button-errorColor 🅲Button-smallSize"
+  className="C9Y-Button-base C9Y-Button-filled C9Y-Button-errorColor C9Y-Button-smallSize"
 >
   Button
 </button>
 ```
 
 Classes for sub-components do not have `-base`, eg for Card, there are classes
-`🅲CardHeader`, `🅲CardFooter`, etc. This pattern is intended to direct styles and
-usage towards using a single variant for each component style.
+`C9Y-CardHeader`, `C9Y-CardFooter`, etc. This pattern is intended to direct
+styles and usage towards using a single variant for each component style.
 
 ## Considered Options
 
 ### Decision - Variants
 
 ```html
-<h1 class="🅲Text-base 🅲Text-h1Variant">Heading 1</h1>
+<h1 class="C9Y-Text-base C9Y-Text-h1Variant">Heading 1</h1>
 ```
 
 Including "Variant" with the className was considered, but it seems heavy
@@ -57,7 +57,7 @@ classes.
 
 ```html
 <button
-  className="🅲Button-base 🅲Button-filled 🅲Button-error-color 🅲Button-small-size"
+  className="C9Y-Button-base C9Y-Button-filled C9Y-Button-error-color C9Y-Button-small-size"
 >
   Button
 </button>
@@ -72,7 +72,7 @@ styles in JS more difficult.
 
 ### Negative Consequences
 
-- Override styles use the library 🅲 emoji which is fun, but isn't easy to
+- Override styles use the library C9Y- emoji which is fun, but isn't easy to
   copy/paste
 
 ## Links <!-- optional -->

--- a/src/components/Active/__snapshots__/Active.spec.js.snap
+++ b/src/components/Active/__snapshots__/Active.spec.js.snap
@@ -2,20 +2,20 @@
 
 exports[`<Active /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Active-base"
+  class="C9Y-Active-base"
   data-id="test-guid"
   data-testid="active"
 >
   <button
     aria-controls="test-guid"
-    class="🅲Link-base 🅲Link-text 🅲ActiveAction"
+    class="C9Y-Link-base C9Y-Link-text C9Y-ActiveAction"
     type="button"
   >
     Action
   </button>
   <div
     aria-hidden="true"
-    class="🅲ActiveContent"
+    class="C9Y-ActiveContent"
     id="test-guid"
   >
     Content

--- a/src/components/Alert/Alert.spec.js
+++ b/src/components/Alert/Alert.spec.js
@@ -14,7 +14,7 @@ describe('<Alert/>', () => {
     render(<Alert color='success'>Warning!</Alert>)
 
     expect(screen.getByRole('alert')).toHaveClass(
-      '🅲Alert-base 🅲Alert-filled 🅲Alert-successColor',
+      'C9Y-Alert-base C9Y-Alert-filled C9Y-Alert-successColor',
     )
     expect(screen.getByRole('alert')).toHaveAttribute('role', 'alert')
   })

--- a/src/components/Alert/Alert.stories.mdx
+++ b/src/components/Alert/Alert.stories.mdx
@@ -19,12 +19,12 @@ an uncontrolled Alert.
 <Canvas>
   <Story name='Alert'>
     <Alert color='primary'>
-      <Text variant='h3' className='🅲AlertHeading'>
+      <Text variant='h3' className='C9Y-AlertHeading'>
         Well done!
       </Text>
       <Text>You successfully read this important alert message.</Text>
       <hr className='my-2' />
-      <Link href='#demo' className='🅲AlertLink'>
+      <Link href='#demo' className='C9Y-AlertLink'>
         Go home
       </Link>
     </Alert>
@@ -40,7 +40,7 @@ on click.
 
 <Active defaultActive>
   <Alert color='primary' dismissible>
-    <Text variant='h3' className='🅲AlertHeading'>
+    <Text variant='h3' className='C9Y-AlertHeading'>
       Success!
     </Text>
     <Text>You created a dismissible alert 👋</Text>

--- a/src/components/Alert/Alert.styles.ts
+++ b/src/components/Alert/Alert.styles.ts
@@ -7,7 +7,7 @@ const { theme } = getMergedConfig()
 
 export const alertStyles: Record<string, unknown> = {
   // BASE
-  '.🅲Alert-base': {
+  '.C9Y-Alert-base': {
     // Make the alert container a flex container by default with space-between
     // to align close button to right side
     display: 'flex',
@@ -15,16 +15,16 @@ export const alertStyles: Record<string, unknown> = {
     justifyContent: 'space-between',
   },
 
-  '.🅲Alert-dismissible': {
+  '.C9Y-Alert-dismissible': {
     opacity: 1,
     transition: 'opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
   },
-  '.🅲Alert-dismissed': {
+  '.C9Y-Alert-dismissed': {
     opacity: 0,
   },
 
   // VARIANTS
-  '.🅲Alert-filled': {
+  '.C9Y-Alert-filled': {
     padding: theme.spacing[2],
     background: theme.colors.primary[100],
     color: theme.colors.primary[500],
@@ -32,7 +32,7 @@ export const alertStyles: Record<string, unknown> = {
     borderRadius: theme.borderRadius.md,
     borderColor: theme.colors.primary[300],
 
-    '& .🅲AlertLink': {
+    '& .C9Y-AlertLink': {
       fontWeight: theme.fontWeight.bold,
     },
 
@@ -41,17 +41,17 @@ export const alertStyles: Record<string, unknown> = {
   },
 
   // ELEMENTS
-  '.🅲AlertContent': {
+  '.C9Y-AlertContent': {
     flexGrow: 1,
     flexShrink: 1,
   },
 
-  '.🅲AlertHeading': {
+  '.C9Y-AlertHeading': {
     color: 'inherit',
     marginBottom: theme.spacing[2],
   },
 
-  '.🅲AlertClose': {
+  '.C9Y-AlertClose': {
     flexShrink: 0,
     marginLeft: theme.spacing[1],
     color: 'inherit',
@@ -64,12 +64,12 @@ export const alertStyles: Record<string, unknown> = {
 // Example of adding theme colors to an alert variant
 // const themeColors = ['info', 'success', 'warning', 'error'] as const
 // themeColors.forEach((color) => {
-//   Alert[`.🅲Alert-filled.🅲Alert-${color}Color`] = {
+//   Alert[`.C9Y-Alert-filled.C9Y-Alert-${color}Color`] = {
 //     'background': theme.colors[color][100],
 //     'borderColor': theme.colors[color][300],
 //     'color': theme.colors[color][500],
 
-//     '& .🅲Alert-link': {
+//     '& .C9Y-Alert-link': {
 //       color: theme.colors[color][500],
 //       fontWeight: theme.fontWeight.bold,
 //     },

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -69,11 +69,11 @@ export const Alert: Alert = (props) => {
   return element({
     role: 'alert',
     componentCx: [
-      `🅲Alert-base 🅲Alert-${variant}`,
+      `C9Y-Alert-base C9Y-Alert-${variant}`,
       {
-        [`🅲Alert-${color}Color`]: color,
-        '🅲Alert-dismissible': dismissible,
-        '🅲Alert-dismissed': dismissible && !visible,
+        [`C9Y-Alert-${color}Color`]: color,
+        'C9Y-Alert-dismissible': dismissible,
+        'C9Y-Alert-dismissed': dismissible && !visible,
       },
     ],
     'aria-hidden': dismissible ? String(!active) : 'false',
@@ -83,10 +83,10 @@ export const Alert: Alert = (props) => {
         <div className='sr-only'>{ariaTitle || `${color} alert`}</div>
 
         {/* Alert contents */}
-        <div className='🅲AlertContent'>{children}</div>
+        <div className='C9Y-AlertContent'>{children}</div>
 
         {/* Render a close button or null depending on configs */}
-        {dismissible && <Alert.Close className='🅲AlertClose' onClick={deactivate} />}
+        {dismissible && <Alert.Close className='C9Y-AlertClose' onClick={deactivate} />}
       </>
     ),
     ...rest,

--- a/src/components/Alert/__snapshots__/Alert.spec.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`<Alert /> snapshots renders correctly 1`] = `
 <div
   aria-hidden="false"
-  class="🅲Alert-base 🅲Alert-filled 🅲Alert-dangerColor 🅲Alert-dismissible"
+  class="C9Y-Alert-base C9Y-Alert-filled C9Y-Alert-dangerColor C9Y-Alert-dismissible"
   role="alert"
 >
   <div
@@ -12,17 +12,17 @@ exports[`<Alert /> snapshots renders correctly 1`] = `
     danger alert
   </div>
   <div
-    class="🅲AlertContent"
+    class="C9Y-AlertContent"
   >
     Warning!
   </div>
   <button
-    class="🅲Close-base 🅲AlertClose"
+    class="C9Y-Close-base C9Y-AlertClose"
     type="button"
   >
     <svg
       aria-label="close"
-      class="🅲Icon-base 🅲Icon-font icon-close"
+      class="C9Y-Icon-base C9Y-Icon-font icon-close"
       role="img"
     >
       <use

--- a/src/components/Badge/Badge.spec.js
+++ b/src/components/Badge/Badge.spec.js
@@ -10,7 +10,7 @@ describe('<Badge />', () => {
   it('When color is passed, then badge-color className is rendered', () => {
     render(<Badge color='primary'>Badge</Badge>)
 
-    expect(screen.getByText('Badge')).toHaveClass('🅲Badge-primaryColor')
+    expect(screen.getByText('Badge')).toHaveClass('C9Y-Badge-primaryColor')
   })
 })
 

--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -6,7 +6,7 @@ const { theme } = getMergedConfig()
 // --------------------------------------------------------
 
 export const badgeStyles = {
-  '.🅲Badge-base': {
+  '.C9Y-Badge-base': {
     display: 'inline-flex',
     alignItems: 'center',
     whiteSpace: 'nowrap',
@@ -17,7 +17,7 @@ export const badgeStyles = {
     },
   },
 
-  '.🅲Badge-filled': {
+  '.C9Y-Badge-filled': {
     padding: '4px 8px',
     color: theme.colors.inverse,
     backgroundColor: theme.colors.gray[700],

--- a/src/components/Badge/Badge.ts
+++ b/src/components/Badge/Badge.ts
@@ -24,7 +24,10 @@ export const Badge: React.FC<BadgeProps> = (props) => {
   }
 
   return element({
-    componentCx: [`🅲Badge-base 🅲Badge-${variant}`, { [`🅲Badge-${color}Color`]: color }],
+    componentCx: [
+      `C9Y-Badge-base C9Y-Badge-${variant}`,
+      { [`C9Y-Badge-${color}Color`]: color },
+    ],
     ...rest,
   })
 }

--- a/src/components/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Badge /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Badge-base 🅲Badge-filled 🅲Badge-primaryColor"
+  class="C9Y-Badge-base C9Y-Badge-filled C9Y-Badge-primaryColor"
   data-testid="badge"
 >
   Badge

--- a/src/components/Button/Button.spec.js
+++ b/src/components/Button/Button.spec.js
@@ -21,7 +21,7 @@ describe('<Button/>', () => {
     // By default the button should have type button for a11y
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
     // By default the variant primary
-    expect(screen.getByRole('button')).toHaveClass('🅲Button-base 🅲Button-filled')
+    expect(screen.getByRole('button')).toHaveClass('C9Y-Button-base C9Y-Button-filled')
     // TODO: Is it possible to get the classes from the element and just check that?
     // ...there shouldn't be any other classes
   })
@@ -35,7 +35,7 @@ describe('<Button/>', () => {
   it('When `variant` is passed, then it should be used as base className value', () => {
     render(<Button variant='demo'>Button</Button>)
 
-    expect(screen.getByRole('button')).toHaveClass('🅲Button-base 🅲Button-demo')
+    expect(screen.getByRole('button')).toHaveClass('C9Y-Button-base C9Y-Button-demo')
   })
 
   it('When `color` is passed, then the color className should render', () => {
@@ -49,10 +49,10 @@ describe('<Button/>', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Button' })).toHaveClass(
-      '🅲Button-base 🅲Button-filled 🅲Button-infoColor',
+      'C9Y-Button-base C9Y-Button-filled C9Y-Button-infoColor',
     )
     expect(screen.getByRole('button', { name: 'Variant Button' })).toHaveClass(
-      '🅲Button-base 🅲Button-demo 🅲Button-infoColor',
+      'C9Y-Button-base C9Y-Button-demo C9Y-Button-infoColor',
     )
   })
 
@@ -67,10 +67,10 @@ describe('<Button/>', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Button' })).toHaveClass(
-      '🅲Button-base 🅲Button-filled 🅲Button-smSize',
+      'C9Y-Button-base C9Y-Button-filled C9Y-Button-smSize',
     )
     expect(screen.getByRole('button', { name: 'Variant Button' })).toHaveClass(
-      '🅲Button-base 🅲Button-demo 🅲Button-smSize',
+      'C9Y-Button-base C9Y-Button-demo C9Y-Button-smSize',
     )
   })
 })

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -26,20 +26,20 @@ Pass a `filled` or `outlined` variant to set a button style.
   ]}
 >
   <Button variant='filled'>Button</Button>
-  <Button variant='filled' className='C9Y--hover'>
+  <Button variant='filled' className='C9Y-hover'>
     Button
   </Button>
-  <Button variant='filled' className='C9Y--active'>
+  <Button variant='filled' className='C9Y-active'>
     Button
   </Button>
   <Button variant='filled' disabled>
     Button
   </Button>
   <Button variant='outlined'>Button</Button>
-  <Button variant='outlined' className='C9Y--hover'>
+  <Button variant='outlined' className='C9Y-hover'>
     Button
   </Button>
-  <Button variant='outlined' className='C9Y--active'>
+  <Button variant='outlined' className='C9Y-active'>
     Button
   </Button>
   <Button variant='outlined' disabled>

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -26,20 +26,20 @@ Pass a `filled` or `outlined` variant to set a button style.
   ]}
 >
   <Button variant='filled'>Button</Button>
-  <Button variant='filled' className='🅲-hover'>
+  <Button variant='filled' className='C9Y--hover'>
     Button
   </Button>
-  <Button variant='filled' className='🅲-active'>
+  <Button variant='filled' className='C9Y--active'>
     Button
   </Button>
   <Button variant='filled' disabled>
     Button
   </Button>
   <Button variant='outlined'>Button</Button>
-  <Button variant='outlined' className='🅲-hover'>
+  <Button variant='outlined' className='C9Y--hover'>
     Button
   </Button>
-  <Button variant='outlined' className='🅲-active'>
+  <Button variant='outlined' className='C9Y--active'>
     Button
   </Button>
   <Button variant='outlined' disabled>

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -7,7 +7,7 @@ const { theme } = getMergedConfig()
 
 export const buttonStyles = {
   // BASE
-  '.🅲Button-base': {
+  '.C9Y-Button-base': {
     alignItems: 'center',
     display: 'inline-flex',
     justifyContent: 'center',
@@ -16,14 +16,14 @@ export const buttonStyles = {
     userSelect: 'none', // Prevent text selection on click of buttons
     whiteSpace: 'nowrap', // By default button content shouldn't wrap
 
-    '&.🅲-disabled': {
+    '&.C9Y--disabled': {
       cursor: 'default',
       pointerEvents: 'none',
     },
   },
 
   // VARIANTS
-  '.🅲Button-filled': {
+  '.C9Y-Button-filled': {
     height: '2rem',
     padding: '0 1rem',
     backgroundColor: theme.colors.primary[500],
@@ -34,24 +34,24 @@ export const buttonStyles = {
 
     transition: 'background-color 0.15s linear',
 
-    '&:hover, &.🅲-hover': {
+    '&:hover, &.C9Y--hover': {
       borderColor: theme.colors.primary[500],
       backgroundColor: theme.colors.primary[700],
     },
-    '&:active, &.🅲-active': {
+    '&:active, &.C9Y--active': {
       borderColor: theme.colors.primary[700],
       backgroundColor: theme.colors.primary[900],
     },
-    '&.🅲-disabled': {
+    '&.C9Y--disabled': {
       borderColor: theme.colors.primary[300],
       backgroundColor: theme.colors.primary[300],
     },
 
     // For buttons with color options you'll typically define them in each variant
     // like:
-    // '&.🅲Button-errorColor': { ... }
+    // '&.C9Y-Button-errorColor': { ... }
   },
-  '.🅲Button-outlined': {
+  '.C9Y-Button-outlined': {
     height: '2rem',
     padding: '0 1rem',
     backgroundColor: 'transparent',
@@ -62,28 +62,28 @@ export const buttonStyles = {
 
     transition: 'color 0.15s linear',
 
-    '&:hover, &.🅲-hover': {
+    '&:hover, &.C9Y--hover': {
       borderColor: theme.colors.primary[700],
       color: theme.colors.primary[700],
     },
-    '&:active, &.🅲-active': {
+    '&:active, &.C9Y--active': {
       borderColor: theme.colors.primary[900],
       color: theme.colors.primary[900],
     },
-    '&.🅲-disabled': {
+    '&.C9Y--disabled': {
       borderColor: theme.colors.primary[300],
       color: theme.colors.primary[300],
     },
   },
 
   // SIZES
-  '.🅲Button-smallSize': {
+  '.C9Y-Button-smallSize': {
     height: '1.5rem',
     borderRadius: theme.borderRadius.md,
     fontSize: theme.fontSize.small,
     padding: '0rem 0.5rem',
   },
-  '.🅲Button-largeSize': {
+  '.C9Y-Button-largeSize': {
     height: '2.5rem',
     borderRadius: theme.borderRadius.lg,
     fontSize: theme.fontSize.large,

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -34,7 +34,7 @@ export const buttonStyles = {
 
     transition: 'background-color 0.15s linear',
 
-    '&:hover, &.C9Y-over': {
+    '&:hover, &.C9Y-hover': {
       borderColor: theme.colors.primary[500],
       backgroundColor: theme.colors.primary[700],
     },

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -16,7 +16,7 @@ export const buttonStyles = {
     userSelect: 'none', // Prevent text selection on click of buttons
     whiteSpace: 'nowrap', // By default button content shouldn't wrap
 
-    '&.C9Y--disabled': {
+    '&.C9Y-disabled': {
       cursor: 'default',
       pointerEvents: 'none',
     },
@@ -34,15 +34,15 @@ export const buttonStyles = {
 
     transition: 'background-color 0.15s linear',
 
-    '&:hover, &.C9Y--hover': {
+    '&:hover, &.C9Y-over': {
       borderColor: theme.colors.primary[500],
       backgroundColor: theme.colors.primary[700],
     },
-    '&:active, &.C9Y--active': {
+    '&:active, &.C9Y-active': {
       borderColor: theme.colors.primary[700],
       backgroundColor: theme.colors.primary[900],
     },
-    '&.C9Y--disabled': {
+    '&.C9Y-disabled': {
       borderColor: theme.colors.primary[300],
       backgroundColor: theme.colors.primary[300],
     },
@@ -62,15 +62,15 @@ export const buttonStyles = {
 
     transition: 'color 0.15s linear',
 
-    '&:hover, &.C9Y--hover': {
+    '&:hover, &.C9Y-hover': {
       borderColor: theme.colors.primary[700],
       color: theme.colors.primary[700],
     },
-    '&:active, &.C9Y--active': {
+    '&:active, &.C9Y-active': {
       borderColor: theme.colors.primary[900],
       color: theme.colors.primary[900],
     },
-    '&.C9Y--disabled': {
+    '&.C9Y-disabled': {
       borderColor: theme.colors.primary[300],
       color: theme.colors.primary[300],
     },

--- a/src/components/Button/Button.ts
+++ b/src/components/Button/Button.ts
@@ -47,10 +47,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) =>
     as: merged.href ? 'a' : 'button',
     type: merged.href ? undefined : 'button',
     componentCx: [
-      `🅲Button-base 🅲Button-${variant}`,
+      `C9Y-Button-base C9Y-Button-${variant}`,
       {
-        [`🅲Button-${color}Color`]: color,
-        [`🅲Button-${size}Size`]: size,
+        [`C9Y-Button-${color}Color`]: color,
+        [`C9Y-Button-${size}Size`]: size,
         'w-full': fullWidth,
       },
     ],

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button /> Snapshots renders brand color correctly 1`] = `
 <button
-  class="🅲Button-base 🅲Button-filled 🅲Button-successColor"
+  class="C9Y-Button-base C9Y-Button-filled C9Y-Button-successColor"
   type="button"
 >
   Componentry
@@ -11,7 +11,7 @@ exports[`<Button /> Snapshots renders brand color correctly 1`] = `
 
 exports[`<Button /> Snapshots renders defaults correctly 1`] = `
 <button
-  class="🅲Button-base 🅲Button-filled"
+  class="C9Y-Button-base C9Y-Button-filled"
   type="button"
 >
   Componentry
@@ -20,7 +20,7 @@ exports[`<Button /> Snapshots renders defaults correctly 1`] = `
 
 exports[`<Button /> Snapshots renders large outline correctly 1`] = `
 <button
-  class="🅲Button-base 🅲Button-filled 🅲Button-lgSize"
+  class="C9Y-Button-base C9Y-Button-filled C9Y-Button-lgSize"
   type="button"
 >
   Componentry

--- a/src/components/Card/Card.styles.ts
+++ b/src/components/Card/Card.styles.ts
@@ -6,7 +6,7 @@ const { theme } = getMergedConfig()
 // --------------------------------------------------------
 
 export const cardStyles = {
-  '.🅲Card-base': {
+  '.C9Y-Card-base': {
     position: 'relative',
     display: 'flex',
     flexDirection: 'column',
@@ -15,14 +15,14 @@ export const cardStyles = {
     backgroundClip: 'border-box',
   },
 
-  '.🅲Card-outlined': {
+  '.C9Y-Card-outlined': {
     backgroundColor: theme.colors.background,
     border: `${theme.borderWidth.DEFAULT} solid ${theme.borderColor.DEFAULT}`,
     borderRadius: theme.borderRadius.md,
   },
 
   // --- BODY SUB-COMPONENT
-  '.🅲CardBody': {
+  '.C9Y-CardBody': {
     // Enable `flex-grow: 1` for decks and groups so that card blocks take up
     // as much space as possible, ensuring footers are aligned to the bottom.
     flex: '1 1 auto',
@@ -30,7 +30,7 @@ export const cardStyles = {
   },
 
   // --- HEADER SUB-COMPONENT
-  '.🅲CardHeader': {
+  '.C9Y-CardHeader': {
     padding: theme.spacing[2],
     //   margin-bottom: 0; // Removes the default margin-bottom of <hN>
     backgroundColor: theme.colors.background,
@@ -42,7 +42,7 @@ export const cardStyles = {
   },
 
   // --- FOOTER SUB-COMPONENT
-  '.🅲CardFooter': {
+  '.C9Y-CardFooter': {
     padding: theme.spacing[2],
     backgroundColor: theme.colors.background,
     borderTop: `${theme.borderWidth.DEFAULT} solid ${theme.borderColor.DEFAULT}`,
@@ -53,11 +53,11 @@ export const cardStyles = {
   },
 
   // --- TITLE SUB-COMPONENT
-  '.🅲CardTitle': {
+  '.C9Y-CardTitle': {
     fontSize: theme.fontSize.h3,
     color: theme.colors.gray[900], // Matches default header color
   },
-  '.🅲CardSubtitle': {
+  '.C9Y-CardSubtitle': {
     fontSize: theme.fontSize.small,
     color: theme.colors.gray[600],
   },

--- a/src/components/Card/Card.ts
+++ b/src/components/Card/Card.ts
@@ -49,7 +49,7 @@ export const Card = ((props) => {
   }
 
   return element({
-    componentCx: `🅲Card-base 🅲Card-${variant}`,
+    componentCx: `C9Y-Card-base C9Y-Card-${variant}`,
     ...rest,
   })
 }) as Card

--- a/src/components/Card/__snapshots__/Card.spec.js.snap
+++ b/src/components/Card/__snapshots__/Card.spec.js.snap
@@ -2,26 +2,26 @@
 
 exports[`<Card /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Card-base 🅲Card-outlined"
+  class="C9Y-Card-base C9Y-Card-outlined"
   data-testid="card"
 >
   <div
-    class="🅲CardHeader"
+    class="C9Y-CardHeader"
   >
     Header
   </div>
   <div
-    class="🅲CardBody"
+    class="C9Y-CardBody"
   >
     <h4
-      class="🅲CardTitle"
+      class="C9Y-CardTitle"
     >
       Title
     </h4>
     Body
   </div>
   <div
-    class="🅲CardFooter"
+    class="C9Y-CardFooter"
   >
     Footer
   </div>

--- a/src/components/Close/Close.stories.mdx
+++ b/src/components/Close/Close.stories.mdx
@@ -12,7 +12,7 @@ import { Close } from './Close'
 # Close
 
 The Close component wraps an instance of Icon to create an accessible close element for
-the Alert and Modal components. The `🅲Close-base` class provides a target for custom
+the Alert and Modal components. The `C9Y-Close-base` class provides a target for custom
 styling when needed.
 
 <Story name='Close'>

--- a/src/components/Close/Close.styles.ts
+++ b/src/components/Close/Close.styles.ts
@@ -1,7 +1,7 @@
 //                                        <Close /> styles
 // --------------------------------------------------------
 
-// The 🅲Close-base class allows for targeted styles for close buttons. The
+// The C9Y-Close-base class allows for targeted styles for close buttons. The
 // .icon-close can also be styled for SVG customizations.
 //
 // 📝 Close originally included a `color` and `fontSize` style, but due to
@@ -12,7 +12,7 @@
 //
 // ℹ️ The background image styles for close icons is located in the Icon styles
 export const closeStyles = {
-  '.🅲Close-base': {
+  '.C9Y-Close-base': {
     // Layout
     alignItems: 'center',
     display: 'inline-flex',

--- a/src/components/Close/Close.tsx
+++ b/src/components/Close/Close.tsx
@@ -11,7 +11,7 @@ export interface CloseProps extends ComponentBaseProps<'button'> {
 export const closeBase: CloseProps = {
   as: 'button',
   type: 'button',
-  componentCx: `🅲Close-base`,
+  componentCx: `C9Y-Close-base`,
   children: <Icon id='close' />,
 }
 

--- a/src/components/Close/__snapshots__/Close.spec.js.snap
+++ b/src/components/Close/__snapshots__/Close.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`<Close /> snapshots renders correctly 1`] = `
 <button
-  class="🅲Close-base"
+  class="C9Y-Close-base"
   data-testid="close"
   type="button"
 >
   <svg
     aria-label="close"
-    class="🅲Icon-base 🅲Icon-font icon-close"
+    class="C9Y-Icon-base C9Y-Icon-font icon-close"
     role="img"
   >
     <use

--- a/src/components/Drawer/__snapshots__/Drawer.spec.js.snap
+++ b/src/components/Drawer/__snapshots__/Drawer.spec.js.snap
@@ -2,21 +2,21 @@
 
 exports[`<Drawer /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Drawer-base"
+  class="C9Y-Drawer-base"
   data-id="test-guid"
   data-testid="drawer"
 >
   <button
     aria-controls="test-guid"
     aria-expanded="false"
-    class="🅲Link-base 🅲Link-text 🅲DrawerAction"
+    class="C9Y-Link-base C9Y-Link-text C9Y-DrawerAction"
     type="button"
   >
     Action
   </button>
   <div
     aria-hidden="true"
-    class="🅲DrawerContent"
+    class="C9Y-DrawerContent"
     id="test-guid"
   >
     Content

--- a/src/components/Dropdown/Dropdown.spec.js
+++ b/src/components/Dropdown/Dropdown.spec.js
@@ -26,7 +26,7 @@ describe('<Dropdown />', () => {
       </Dropdown>,
     )
 
-    expect(screen.getByTestId('dropdown')).toHaveClass('🅲Dropdown-bottom') // default value
+    expect(screen.getByTestId('dropdown')).toHaveClass('C9Y-Dropdown-bottom') // default value
 
     rerender(
       <Dropdown data-testid='dropdown' direction='top'>
@@ -35,7 +35,7 @@ describe('<Dropdown />', () => {
       </Dropdown>,
     )
 
-    expect(screen.getByTestId('dropdown')).toHaveClass('🅲Dropdown-top') // default value
+    expect(screen.getByTestId('dropdown')).toHaveClass('C9Y-Dropdown-top') // default value
   })
 })
 

--- a/src/components/Dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -2,14 +2,14 @@
 
 exports[`<Dropdown /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Dropdown-base 🅲Dropdown-bottom"
+  class="C9Y-Dropdown-base C9Y-Dropdown-bottom"
   data-id="test-guid"
   data-testid="dropdown"
 >
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="🅲Button-base 🅲Button-filled 🅲DropdownAction"
+    class="C9Y-Button-base C9Y-Button-filled C9Y-DropdownAction"
     id="test-guid"
     type="button"
   >
@@ -18,15 +18,15 @@ exports[`<Dropdown /> snapshots renders correctly 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="test-guid"
-    class="🅲DropdownContent"
+    class="C9Y-DropdownContent"
   >
     <div
-      class="🅲DropdownItem"
+      class="C9Y-DropdownItem"
     >
       Item 1
     </div>
     <div
-      class="🅲DropdownItem"
+      class="C9Y-DropdownItem"
     >
       Item 2
     </div>

--- a/src/components/Dropdown/_dropdown.scss
+++ b/src/components/Dropdown/_dropdown.scss
@@ -6,7 +6,7 @@
 
 // The dropdown wrapper element handles creating a relative container that the
 // content is absolutely positioned off of
-.🅲-dropdown {
+.C9Y--dropdown {
   position: relative;
   // Default dropdown container to inline-block so that click area is constrained
   // to dropdown action
@@ -28,7 +28,7 @@
 // --- Content styles
 //
 
-.🅲-dropdown-content {
+.C9Y--dropdown-content {
   display: block;
   position: absolute;
   z-index: $zindex-dropdown;
@@ -88,23 +88,23 @@
 //
 
 .dropdown-sm {
-  .🅲-dropdown-content {
+  .C9Y--dropdown-content {
     font-size: $dropdown-font-size-sm;
     font-weight: $dropdown-font-weight-sm;
   }
 
-  .🅲-dropdown-item {
+  .C9Y--dropdown-item {
     padding: $dropdown-item-padding-y-sm $dropdown-item-padding-x-sm;
   }
 }
 
 .dropdown-lg {
-  .🅲-dropdown-content {
+  .C9Y--dropdown-content {
     font-size: $dropdown-font-size-lg;
     font-weight: $dropdown-font-weight-lg;
   }
 
-  .🅲-dropdown-item {
+  .C9Y--dropdown-item {
     padding: $dropdown-item-padding-y-lg $dropdown-item-padding-x-lg;
   }
 }
@@ -115,7 +115,7 @@
 
 // Dropdown items
 // `<button>`-specific styles are denoted with `// For <button>s`
-.🅲-dropdown-item {
+.C9Y--dropdown-item {
   display: block;
   width: 100%;
   padding: $dropdown-item-padding-y $dropdown-item-padding-x;

--- a/src/components/Dropdown/_dropdown.scss
+++ b/src/components/Dropdown/_dropdown.scss
@@ -6,7 +6,7 @@
 
 // The dropdown wrapper element handles creating a relative container that the
 // content is absolutely positioned off of
-.C9Y--dropdown {
+.C9Y-dropdown {
   position: relative;
   // Default dropdown container to inline-block so that click area is constrained
   // to dropdown action
@@ -28,7 +28,7 @@
 // --- Content styles
 //
 
-.C9Y--dropdown-content {
+.C9Y-dropdown-content {
   display: block;
   position: absolute;
   z-index: $zindex-dropdown;
@@ -88,23 +88,23 @@
 //
 
 .dropdown-sm {
-  .C9Y--dropdown-content {
+  .C9Y-dropdown-content {
     font-size: $dropdown-font-size-sm;
     font-weight: $dropdown-font-weight-sm;
   }
 
-  .C9Y--dropdown-item {
+  .C9Y-dropdown-item {
     padding: $dropdown-item-padding-y-sm $dropdown-item-padding-x-sm;
   }
 }
 
 .dropdown-lg {
-  .C9Y--dropdown-content {
+  .C9Y-dropdown-content {
     font-size: $dropdown-font-size-lg;
     font-weight: $dropdown-font-weight-lg;
   }
 
-  .C9Y--dropdown-item {
+  .C9Y-dropdown-item {
     padding: $dropdown-item-padding-y-lg $dropdown-item-padding-x-lg;
   }
 }
@@ -115,7 +115,7 @@
 
 // Dropdown items
 // `<button>`-specific styles are denoted with `// For <button>s`
-.C9Y--dropdown-item {
+.C9Y-dropdown-item {
   display: block;
   width: 100%;
   padding: $dropdown-item-padding-y $dropdown-item-padding-x;

--- a/src/components/FormGroup/FormGroup.styles.ts
+++ b/src/components/FormGroup/FormGroup.styles.ts
@@ -6,7 +6,7 @@ const { theme } = getMergedConfig()
 // --------------------------------------------------------
 
 export const formGroupStyles = {
-  '.🅲FormGroup': {
+  '.C9Y-FormGroup': {
     marginBottom: theme.spacing[2],
   },
 }

--- a/src/components/FormGroup/__snapshots__/FormGroup.spec.js.snap
+++ b/src/components/FormGroup/__snapshots__/FormGroup.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<FormGroup /> snapshots renders correctly 1`] = `
 <div
-  class="🅲FormGroup"
+  class="C9Y-FormGroup"
   data-testid="formgroup"
 />
 `;

--- a/src/components/Icon/Icon.styles.ts
+++ b/src/components/Icon/Icon.styles.ts
@@ -5,13 +5,13 @@ import { StylesDefinition } from '../../utils/types'
 
 export const iconStyles: IconStyles = {
   // BASE
-  '.🅲Icon-base': {
+  '.C9Y-Icon-base': {
     display: 'inline-block',
     userSelect: 'none',
   },
 
   // VARIANTS
-  '.🅲Icon-font': {
+  '.C9Y-Icon-font': {
     // 1em width+height makes icons font-sized by default 🔮
     height: '1em',
     width: '1em',
@@ -31,7 +31,7 @@ export const iconStyles: IconStyles = {
 
 export type IconStyles = {
   /** Base class applied to all variants for shared structural styles */
-  '.🅲Icon-base': StylesDefinition
+  '.C9Y-Icon-base': StylesDefinition
   /** Variant class applied when `variant="font"` */
-  '.🅲Icon-font': StylesDefinition
+  '.C9Y-Icon-font': StylesDefinition
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -45,7 +45,7 @@ export const Icon: FC<IconProps> = (props) => {
   return element({
     as: hasMappedElement ? iconElementsMap[id] : 'svg',
     children: hasMappedElement ? undefined : <use href={`${externalURI}#${id}`} />,
-    componentCx: `🅲Icon-base 🅲Icon-${variant} icon-${id}`,
+    componentCx: `C9Y-Icon-base C9Y-Icon-${variant} icon-${id}`,
     role: 'img',
     'aria-label': id,
     ...rest,

--- a/src/components/Icon/__snapshots__/Icon.spec.js.snap
+++ b/src/components/Icon/__snapshots__/Icon.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`<Icon /> snapshots renders correctly 1`] = `
 <svg
   aria-label="test"
-  class="🅲Icon-base 🅲Icon-font icon-test"
+  class="C9Y-Icon-base C9Y-Icon-font icon-test"
   data-testid="icon"
   role="img"
 >

--- a/src/components/Input/Input.stories.mdx
+++ b/src/components/Input/Input.stories.mdx
@@ -32,7 +32,7 @@ import { Input } from './Input'
 Try to always include a label for inputs, they can be hidden using the `.sr-only` class
 for screen readers.
 
-<div className='C9Y--form-group'>
+<div className='C9Y-FormGroup-base'>
   <Input>
     <Input.Label className='sr-only'>Storybook</Input.Label>
     <Input.Field />

--- a/src/components/Input/Input.stories.mdx
+++ b/src/components/Input/Input.stories.mdx
@@ -32,7 +32,7 @@ import { Input } from './Input'
 Try to always include a label for inputs, they can be hidden using the `.sr-only` class
 for screen readers.
 
-<div className='🅲-form-group'>
+<div className='C9Y--form-group'>
   <Input>
     <Input.Label className='sr-only'>Storybook</Input.Label>
     <Input.Field />

--- a/src/components/Input/Input.styles.ts
+++ b/src/components/Input/Input.styles.ts
@@ -47,7 +47,7 @@ export const inputStyles = {
     },
 
     // Invalid inputs
-    '&:invalid, &.C9Y--invalid': {
+    '&:invalid, &.C9Y-invalid': {
       background: theme.colors.error[100],
       color: theme.colors.error[500],
       borderColor: theme.colors.error[500],

--- a/src/components/Input/Input.styles.ts
+++ b/src/components/Input/Input.styles.ts
@@ -7,7 +7,7 @@ const { theme } = getMergedConfig()
 
 export const inputStyles = {
   // FIELD
-  '.🅲InputField': {
+  '.C9Y-InputField': {
     display: 'block',
     width: '100%',
     padding: `${theme.spacing[1]} ${theme.spacing[2]}`,
@@ -47,7 +47,7 @@ export const inputStyles = {
     },
 
     // Invalid inputs
-    '&:invalid, &.🅲-invalid': {
+    '&:invalid, &.C9Y--invalid': {
       background: theme.colors.error[100],
       color: theme.colors.error[500],
       borderColor: theme.colors.error[500],
@@ -55,7 +55,7 @@ export const inputStyles = {
   },
 
   // LABEL
-  '.🅲InputLabel': {
+  '.C9Y-InputLabel': {
     display: 'inline-block',
     marginBottom: theme.spacing[0.5],
     color: theme.colors.gray[700],
@@ -63,7 +63,7 @@ export const inputStyles = {
   },
 
   // DESCRIPTION
-  '.🅲InputDescription': {
+  '.C9Y-InputDescription': {
     display: 'block',
     margin: theme.spacing[0.5],
     color: theme.colors.gray[700],
@@ -71,7 +71,7 @@ export const inputStyles = {
   },
 
   // Error
-  '.🅲InputError': {
+  '.C9Y-InputError': {
     display: 'block',
     margin: theme.spacing[0.5],
     color: theme.colors.error[500],

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -84,7 +84,7 @@ Input.Field = function InputField(props) {
     componentCx: [
       'C9Y-InputField',
       {
-        'C9Y--invalid': invalid,
+        'C9Y-invalid': invalid,
       },
     ],
     ...rest,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -82,9 +82,9 @@ Input.Field = function InputField(props) {
     id: ctx.guid, // aria -> htmlFor
     invalid: invalid ? true : undefined,
     componentCx: [
-      '🅲InputField',
+      'C9Y-InputField',
       {
-        '🅲-invalid': invalid,
+        'C9Y--invalid': invalid,
       },
     ],
     ...rest,
@@ -101,7 +101,7 @@ Input.Label = function InputLabel(props) {
   return element({
     as: 'label',
     htmlFor: ctx.guid, // aria -> id
-    componentCx: '🅲InputLabel',
+    componentCx: 'C9Y-InputLabel',
     ...useTheme<InputLabelProps>('InputLabel'),
     ...props,
   })

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -5,23 +5,23 @@ exports[`<Input /> snapshots renders correctly 1`] = `
   data-testid="input"
 >
   <label
-    class="🅲InputLabel"
+    class="C9Y-InputLabel"
     for="test-guid"
   >
     Storybook
   </label>
   <input
-    class="🅲InputField"
+    class="C9Y-InputField"
     id="test-guid"
     type="text"
   />
   <div
-    class="🅲InputDescription"
+    class="C9Y-InputDescription"
   >
     Really important input!
   </div>
   <div
-    class="🅲InputError"
+    class="C9Y-InputError"
   >
     Oh no!
   </div>

--- a/src/components/Link/Link.spec.js
+++ b/src/components/Link/Link.spec.js
@@ -15,7 +15,9 @@ describe('<Link/>', () => {
       </Link>,
     )
 
-    expect(screen.getByText('Link')).toHaveClass('🅲Link-base 🅲Link-text text-success')
+    expect(screen.getByText('Link')).toHaveClass(
+      'C9Y-Link-base C9Y-Link-text text-success',
+    )
   })
 })
 

--- a/src/components/Link/Link.styles.ts
+++ b/src/components/Link/Link.styles.ts
@@ -7,13 +7,13 @@ const { theme } = getMergedConfig()
 
 export const linkStyles = {
   // BASE
-  '.🅲Link-base': {
+  '.C9Y-Link-base': {
     // Reset browser defaults for when Link renders a button element
     border: 'none',
   },
 
   // VARIANTS
-  '.🅲Link-text': {
+  '.C9Y-Link-text': {
     fontSize: theme.fontSize.body,
     color: theme.colors.primary[500],
     textDecoration: 'underline',
@@ -22,7 +22,7 @@ export const linkStyles = {
     },
   },
 
-  '.🅲Link-inherit': {
+  '.C9Y-Link-inherit': {
     fontSize: 'inherit',
     fontWeight: 'inherit',
     color: theme.colors.primary[500],

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -35,7 +35,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
     ref,
     as: merged.href ? 'a' : 'button',
     type: merged.href ? undefined : 'button',
-    componentCx: `🅲Link-base 🅲Link-${variant}`,
+    componentCx: `C9Y-Link-base C9Y-Link-${variant}`,
     ...merged,
   })
 })

--- a/src/components/Link/__snapshots__/Link.spec.js.snap
+++ b/src/components/Link/__snapshots__/Link.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Link /> snapshots renders correctly 1`] = `
 <a
-  class="🅲Link-base 🅲Link-text"
+  class="C9Y-Link-base C9Y-Link-text"
   data-testid="link"
   href="#test"
 >

--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -12,7 +12,7 @@ const { theme } = getMergedConfig()
 //     div.ModalBody     - Contains modal content
 
 export const modalStyles = {
-  '.🅲ModalOverlay': {
+  '.C9Y-ModalOverlay': {
     position: 'fixed',
     top: 0,
     right: 0,
@@ -23,12 +23,12 @@ export const modalStyles = {
     opacity: 0,
     transition: 'opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
 
-    '&.🅲-active': {
+    '&.C9Y--active': {
       opacity: 0.7,
     },
   },
 
-  '.🅲ModalPositioner': {
+  '.C9Y-ModalPositioner': {
     position: 'fixed',
     top: 0,
     right: 0,
@@ -46,12 +46,12 @@ export const modalStyles = {
     opacity: 0.5,
     transition: 'opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
 
-    '&.🅲-active': {
+    '&.C9Y--active': {
       opacity: 1,
     },
   },
 
-  '.🅲ModalContainer': {
+  '.C9Y-ModalContainer': {
     display: 'flex',
     flexDirection: 'column',
     backgroundColor: theme.colors.background,
@@ -73,43 +73,43 @@ export const modalStyles = {
 
   // --- SIZES
   // 🤔 How to allow users to make modals 100% width for small breakpoints?
-  '.🅲ModalContainer-smSize': {
+  '.C9Y-ModalContainer-smSize': {
     maxWidth: '450px',
   },
 
-  '.🅲ModalContainer-lgSize': {
+  '.C9Y-ModalContainer-lgSize': {
     maxWidth: '900px',
   },
 
   // --- SCROLLING
 
   // Modal overlay scrolling
-  '.🅲ModalPositioner.🅲Modal-overlayScroll': {
+  '.C9Y-ModalPositioner.C9Y-Modal-overlayScroll': {
     overflowX: 'hidden',
     overflowY: 'auto',
   },
 
   // Modal container scrolling
-  '.🅲ModalPositioner.🅲Modal-containerScroll': {
-    '.🅲ModalContainer': {
+  '.C9Y-ModalPositioner.C9Y-Modal-containerScroll': {
+    '.C9Y-ModalContainer': {
       maxHeight: '100%',
       overflowY: 'scroll',
     },
   },
 
   // Modal body scrolling
-  '.🅲ModalPositioner.🅲Modal-bodyScroll': {
-    '.🅲ModalContainer': {
+  '.C9Y-ModalPositioner.C9Y-Modal-bodyScroll': {
+    '.C9Y-ModalContainer': {
       maxHeight: '100%',
     },
 
-    '.🅲ModalBody': {
+    '.C9Y-ModalBody': {
       overflowY: 'scroll',
     },
   },
 
   // --- HEADER
-  '.🅲ModalHeader': {
+  '.C9Y-ModalHeader': {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between', // Put modal header elements (title and dismiss) on opposite ends
@@ -121,7 +121,7 @@ export const modalStyles = {
   },
 
   // --- TITLE
-  '.🅲ModalTitle': {
+  '.C9Y-ModalTitle': {
     marginTop: 0,
     marginBottom: 0,
     lineHeight: theme.lineHeight.none,
@@ -131,7 +131,7 @@ export const modalStyles = {
   },
 
   // --- BODY
-  '.🅲ModalBody': {
+  '.C9Y-ModalBody': {
     position: 'relative',
     // Enable `flex-grow: 1` so that the body take up as much space as possible
     // when should there be a fixed height on `.modal-container`.
@@ -140,7 +140,7 @@ export const modalStyles = {
   },
 
   // --- FOOTER
-  '.🅲ModalFooter': {
+  '.C9Y-ModalFooter': {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/components/Modal/Modal.styles.ts
+++ b/src/components/Modal/Modal.styles.ts
@@ -23,7 +23,7 @@ export const modalStyles = {
     opacity: 0,
     transition: 'opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
 
-    '&.C9Y--active': {
+    '&.C9Y-active': {
       opacity: 0.7,
     },
   },
@@ -46,7 +46,7 @@ export const modalStyles = {
     opacity: 0.5,
     transition: 'opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
 
-    '&.C9Y--active': {
+    '&.C9Y-active': {
       opacity: 1,
     },
   },

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -126,11 +126,11 @@ export const Modal = ((props: ModalProps) => {
   //   div.ModalContainer  - Contains the modal header,body,footer elements
   return (
     <ModalCtx.Provider value={{ active, deactivate, guid }}>
-      <div className={clsx('🅲ModalOverlay', { '🅲-active': visible })} />
+      <div className={clsx('C9Y-ModalOverlay', { 'C9Y--active': visible })} />
       <div
         ref={containerRef}
-        className={clsx(`🅲ModalPositioner 🅲Modal-${scroll}Scroll`, {
-          '🅲-active': visible,
+        className={clsx(`C9Y-ModalPositioner C9Y-Modal-${scroll}Scroll`, {
+          'C9Y--active': visible,
         })}
         role='presentation'
         tabIndex={-1}
@@ -141,9 +141,9 @@ export const Modal = ((props: ModalProps) => {
           ref={contentRef}
           aria-hidden={!active}
           aria-labelledby={guid}
-          className={clsx('🅲ModalContainer', align, {
-            '🅲-active': visible,
-            [`🅲ModalContainer-${size}Size`]: size,
+          className={clsx('C9Y-ModalContainer', align, {
+            'C9Y--active': visible,
+            [`C9Y-ModalContainer-${size}Size`]: size,
           })}
           role='dialog'
           onClick={(evt) => {
@@ -176,7 +176,7 @@ Modal.Header = function ModalHeader(props: ModalHeaderProps) {
   assertContext(ctx)
 
   return element({
-    componentCx: '🅲ModalHeader',
+    componentCx: 'C9Y-ModalHeader',
     children: (
       <>
         {children}
@@ -200,7 +200,7 @@ Modal.Title = function ModalTitle(props) {
   return element({
     as: 'h2',
     id: ctx.guid,
-    componentCx: '🅲ModalTitle',
+    componentCx: 'C9Y-ModalTitle',
     ...useTheme<ModalTitleProps>('ModalTitle'),
     ...props,
   })
@@ -219,7 +219,7 @@ Modal.Body = function ModalBody(props) {
 
   return element({
     ref: bodyRef,
-    componentCx: '🅲ModalBody',
+    componentCx: 'C9Y-ModalBody',
     ...useTheme<ModalBodyProps>('ModalBody'),
     ...props,
   })

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -126,11 +126,11 @@ export const Modal = ((props: ModalProps) => {
   //   div.ModalContainer  - Contains the modal header,body,footer elements
   return (
     <ModalCtx.Provider value={{ active, deactivate, guid }}>
-      <div className={clsx('C9Y-ModalOverlay', { 'C9Y--active': visible })} />
+      <div className={clsx('C9Y-ModalOverlay', { 'C9Y-active': visible })} />
       <div
         ref={containerRef}
         className={clsx(`C9Y-ModalPositioner C9Y-Modal-${scroll}Scroll`, {
-          'C9Y--active': visible,
+          'C9Y-active': visible,
         })}
         role='presentation'
         tabIndex={-1}
@@ -142,7 +142,7 @@ export const Modal = ((props: ModalProps) => {
           aria-hidden={!active}
           aria-labelledby={guid}
           className={clsx('C9Y-ModalContainer', align, {
-            'C9Y--active': visible,
+            'C9Y-active': visible,
             [`C9Y-ModalContainer-${size}Size`]: size,
           })}
           role='dialog'

--- a/src/components/Modal/__snapshots__/Modal.spec.js.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.js.snap
@@ -3,35 +3,35 @@
 exports[`<Modal /> snapshots renders correctly 1`] = `
 HTMLCollection [
   <div
-    class="🅲ModalOverlay 🅲-active"
+    class="C9Y-ModalOverlay C9Y--active"
   />,
   <div
-    class="🅲ModalPositioner 🅲Modal-overlayScroll 🅲-active"
+    class="C9Y-ModalPositioner C9Y-Modal-overlayScroll C9Y--active"
     role="presentation"
     tabindex="-1"
   >
     <div
       aria-hidden="false"
       aria-labelledby="test-guid"
-      class="🅲ModalContainer 🅲-active"
+      class="C9Y-ModalContainer C9Y--active"
       role="dialog"
     >
       <div
-        class="🅲ModalHeader"
+        class="C9Y-ModalHeader"
       >
         <h2
-          class="🅲ModalTitle"
+          class="C9Y-ModalTitle"
           id="test-guid"
         >
           Demo uncontrolled modal
         </h2>
         <button
-          class="🅲Close-base"
+          class="C9Y-Close-base"
           type="button"
         >
           <svg
             aria-label="close"
-            class="🅲Icon-base 🅲Icon-font icon-close"
+            class="C9Y-Icon-base C9Y-Icon-font icon-close"
             role="img"
           >
             <use
@@ -41,14 +41,14 @@ HTMLCollection [
         </button>
       </div>
       <div
-        class="🅲ModalBody"
+        class="C9Y-ModalBody"
       >
         <p>
           This is an uncontrolled modal that will automatically manage its active state using the parent Active component.
         </p>
       </div>
       <div
-        class="🅲ModalFooter btn-container-x"
+        class="C9Y-ModalFooter btn-container-x"
       >
         Modal Footer
       </div>

--- a/src/components/Modal/__snapshots__/Modal.spec.js.snap
+++ b/src/components/Modal/__snapshots__/Modal.spec.js.snap
@@ -3,17 +3,17 @@
 exports[`<Modal /> snapshots renders correctly 1`] = `
 HTMLCollection [
   <div
-    class="C9Y-ModalOverlay C9Y--active"
+    class="C9Y-ModalOverlay C9Y-active"
   />,
   <div
-    class="C9Y-ModalPositioner C9Y-Modal-overlayScroll C9Y--active"
+    class="C9Y-ModalPositioner C9Y-Modal-overlayScroll C9Y-active"
     role="presentation"
     tabindex="-1"
   >
     <div
       aria-hidden="false"
       aria-labelledby="test-guid"
-      class="C9Y-ModalContainer C9Y--active"
+      class="C9Y-ModalContainer C9Y-active"
       role="dialog"
     >
       <div

--- a/src/components/Popover/Popover.spec.js
+++ b/src/components/Popover/Popover.spec.js
@@ -24,7 +24,7 @@ describe('<Popover />', () => {
       </Popover>,
     )
 
-    expect(screen.getByTestId('popover')).toHaveClass('🅲Popover-left')
+    expect(screen.getByTestId('popover')).toHaveClass('C9Y-Popover-left')
   })
 })
 

--- a/src/components/Popover/Popover.styles.ts
+++ b/src/components/Popover/Popover.styles.ts
@@ -9,7 +9,7 @@ const arrowWidth = 4 // in pixels
 
 export const popoverStyles = {
   // --- CONTAINER
-  '.🅲Popover-base': {
+  '.C9Y-Popover-base': {
     // Default align content to dead center of action the specific content styles can
     // then easily move to top/left/right/bottom where needed
     alignItems: 'center',
@@ -19,20 +19,20 @@ export const popoverStyles = {
 
     // Directional styles
 
-    '&.🅲Popover-top': {
-      '.🅲PopoverContent': {
+    '&.C9Y-Popover-top': {
+      '.C9Y-PopoverContent': {
         bottom: '100%',
         justifyContent: 'center',
       },
 
-      '.🅲PopoverContentContents': {
+      '.C9Y-PopoverContentContents': {
         // Top requires bumping bottom 100% again to compensate for container not having
         // any height
         bottom: '100%',
         marginBottom: `${arrowWidth}px`,
       },
 
-      '.🅲PopoverArrow:after': {
+      '.C9Y-PopoverArrow:after': {
         // top: 100%,
         // width: 100%,
         // }
@@ -40,33 +40,33 @@ export const popoverStyles = {
       },
     },
 
-    '&.🅲Popover-right': {
-      '.🅲PopoverContent': {
+    '&.C9Y-Popover-right': {
+      '.C9Y-PopoverContent': {
         left: '100%',
         alignItems: 'center',
       },
 
-      '.🅲PopoverContentContents': {
+      '.C9Y-PopoverContentContents': {
         marginLeft: `${arrowWidth}px`,
       },
 
-      // '.🅲PopoverArrow': {
+      // '.C9Y-PopoverArrow': {
       //   height: '100%',
       //   right: '100%',
       // },
 
-      '.🅲PopoverArrow:after': {
+      '.C9Y-PopoverArrow:after': {
         left: `${arrowWidth * 0.5}px`,
       },
     },
 
-    '&.🅲Popover-bottom': {
-      '.🅲PopoverContent': {
+    '&.C9Y-Popover-bottom': {
+      '.C9Y-PopoverContent': {
         top: '100%',
         justifyContent: 'center',
       },
 
-      '.🅲PopoverContentContents': {
+      '.C9Y-PopoverContentContents': {
         marginTop: `${arrowWidth}px`,
       },
 
@@ -75,18 +75,18 @@ export const popoverStyles = {
       //   width: '100%',
       // },
 
-      '.🅲PopoverArrow:after': {
+      '.C9Y-PopoverArrow:after': {
         top: `${arrowWidth * 0.5}px`,
       },
     },
 
-    '&.🅲Popover-left': {
-      '.🅲PopoverContent': {
+    '&.C9Y-Popover-left': {
+      '.C9Y-PopoverContent': {
         right: '100%',
         alignItems: 'center',
       },
 
-      '.🅲PopoverContentContents': {
+      '.C9Y-PopoverContentContents': {
         marginRight: `${arrowWidth}px`,
         right: 0,
       },
@@ -96,7 +96,7 @@ export const popoverStyles = {
       //   left: '100%',
       // },
 
-      '.🅲PopoverArrow:after': {
+      '.C9Y-PopoverArrow:after': {
         right: `${arrowWidth * 0.5}px`,
       },
     },
@@ -104,17 +104,17 @@ export const popoverStyles = {
 
   // --- Popover action ------------------------------------
 
-  '.🅲PopoverAction': {},
+  '.C9Y-PopoverAction': {},
 
   // Content container overrides the width constraints for parent element
-  '.🅲PopoverContent': {
+  '.C9Y-PopoverContent': {
     width: '300px',
     position: 'absolute',
     display: 'inline-flex',
   },
 
   // Content Element - The content element should be used to wrap a body/header element
-  '.🅲PopoverContentContents': {
+  '.C9Y-PopoverContentContents': {
     display: 'block',
     position: 'absolute',
     maxWidth: '300px',
@@ -140,7 +140,7 @@ export const popoverStyles = {
   // The .tip container creates a containing box of the same height and width as the
   // tip with overflow hidden. Then inside that container we create a square of the
   // same dimensions, and rotate it 45 degrees to create the tip effect
-  '.🅲PopoverArrow': {
+  '.C9Y-PopoverArrow': {
     height: `${arrowWidth}px`,
     overflow: 'hidden',
     width: `${arrowWidth}px`,
@@ -159,13 +159,13 @@ export const popoverStyles = {
 
   // --- BODY
   // Body element should contain popover inner content
-  '.🅲PopoverBody': {
+  '.C9Y-PopoverBody': {
     padding: theme.spacing[2],
     color: theme.colors.gray[700],
   },
 
   // --- HEADING
-  '.🅲PopoverHeading': {
+  '.C9Y-PopoverHeading': {
     padding: theme.spacing[1],
     // Try to guarantee that spacing is correct regardless of div vs h* usage
     marginTop: 0,

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -79,8 +79,8 @@ function PopoverContentElement({
 }) {
   return (
     <div {...rest}>
-      {/* {renderArrow && <div className='🅲PopoverArrow' />} */}
-      <div className='🅲PopoverContentContents'>{children}</div>
+      {/* {renderArrow && <div className='C9Y-PopoverArrow' />} */}
+      <div className='C9Y-PopoverContentContents'>{children}</div>
     </div>
   )
 }

--- a/src/components/Popover/__snapshots__/Popover.spec.js.snap
+++ b/src/components/Popover/__snapshots__/Popover.spec.js.snap
@@ -2,33 +2,33 @@
 
 exports[`<Popover /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Popover-base 🅲Popover-right"
+  class="C9Y-Popover-base C9Y-Popover-right"
   data-id="test-guid"
   data-testid="popover"
 >
   <button
     aria-describedby="test-guid"
-    class="🅲Button-base 🅲Button-filled 🅲PopoverAction"
+    class="C9Y-Button-base C9Y-Button-filled C9Y-PopoverAction"
     type="button"
   >
     Toggle
   </button>
   <div
     aria-hidden="true"
-    class="🅲PopoverContent"
+    class="C9Y-PopoverContent"
     id="test-guid"
     role="tooltip"
   >
     <div
-      class="🅲PopoverContentContents"
+      class="C9Y-PopoverContentContents"
     >
       <h3
-        class="🅲PopoverHeading"
+        class="C9Y-PopoverHeading"
       >
         Fun Fact!
       </h3>
       <div
-        class="🅲PopoverBody"
+        class="C9Y-PopoverBody"
       >
         <span>
           The new Texas Instrument calculators have ABC keyboards because if they had QWERTY keyboards, they would be considered computers and wouldn't be allowed for standardized test taking.

--- a/src/components/Table/Table.styles.ts
+++ b/src/components/Table/Table.styles.ts
@@ -6,26 +6,26 @@ const { theme } = getMergedConfig()
 // --------------------------------------------------------
 
 export const tableStyles = {
-  '.🅲Table-base': {
+  '.C9Y-Table-base': {
     display: 'block',
     width: '100%',
   },
 
-  '.🅲TableHead': {
+  '.C9Y-TableHead': {
     // 📝 Notes
     // - Borders: Table head has a border bottom, and then sibling rows have border top. This
     //   keeps a border below the head for tables with body scrolling.
     borderBottom: `${theme.borderWidth.DEFAULT} solid ${theme.borderColor.DEFAULT}`,
   },
 
-  '.🅲TableHeader': {
+  '.C9Y-TableHeader': {
     fontWeight: theme.fontWeight.bold,
     padding: theme.spacing[1],
   },
 
-  '.🅲TableBody': {},
+  '.C9Y-TableBody': {},
 
-  '.🅲TableRow': {
+  '.C9Y-TableRow': {
     display: 'grid',
     // grid-template-columns: repeat(auto-fit, minmax(1px, 1fr));
     // Default table row grid will be columns of even width
@@ -38,7 +38,7 @@ export const tableStyles = {
     },
   },
 
-  '.🅲TableCell': {
+  '.C9Y-TableCell': {
     padding: theme.spacing[1],
   },
 }

--- a/src/components/Tabs/Tabs.ts
+++ b/src/components/Tabs/Tabs.ts
@@ -70,9 +70,9 @@ const ActionsContainer: React.FC<TabsActionsContainerProps> = (props) => {
   return element({
     role: 'tablist',
     componentCx: [
-      '🅲TabsContainer',
+      'C9Y-TabsContainer',
       {
-        '🅲TabsContainer-pills': pills,
+        'C9Y-TabsContainer-pills': pills,
       },
     ],
     ...rest,

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -2,18 +2,18 @@
 
 exports[`<Tab /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Tabs-base"
+  class="C9Y-Tabs-base"
   data-id="test-guid"
   data-testid="tabs"
 >
   <div
-    class="🅲TabsContainer"
+    class="C9Y-TabsContainer"
     role="tablist"
   >
     <button
       aria-controls="test-guid-one-content"
       aria-selected="true"
-      class="🅲Link-base 🅲Link-text 🅲TabsAction"
+      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction"
       data-active-id="one"
       id="test-guid-one-tab"
       role="tab"
@@ -24,7 +24,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <button
       aria-controls="test-guid-two-content"
       aria-selected="false"
-      class="🅲Link-base 🅲Link-text 🅲TabsAction"
+      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction"
       data-active-id="two"
       id="test-guid-two-tab"
       role="tab"
@@ -35,7 +35,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <button
       aria-controls="test-guid-three-content"
       aria-selected="false"
-      class="🅲Link-base 🅲Link-text 🅲TabsAction"
+      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction"
       data-active-id="three"
       id="test-guid-three-tab"
       role="tab"
@@ -46,7 +46,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <button
       aria-controls="test-guid-four-content"
       aria-selected="false"
-      class="🅲Link-base 🅲Link-text 🅲TabsAction 🅲-disabled 🅲-disabled"
+      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction C9Y--disabled C9Y--disabled"
       data-active-id="four"
       disabled=""
       id="test-guid-four-tab"
@@ -57,12 +57,12 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     </button>
   </div>
   <div
-    class="🅲TabsContentContainer"
+    class="C9Y-TabsContentContainer"
   >
     <div
       aria-hidden="false"
       aria-labelledby="test-guid-one-action"
-      class="🅲TabsContent 🅲-active"
+      class="C9Y-TabsContent C9Y--active"
       id="test-guid-one-content"
       role="tabpanel"
     >
@@ -71,7 +71,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="test-guid-two-action"
-      class="🅲TabsContent 🅲-active"
+      class="C9Y-TabsContent C9Y--active"
       id="test-guid-two-content"
       role="tabpanel"
     >
@@ -80,7 +80,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="test-guid-three-action"
-      class="🅲TabsContent 🅲-active"
+      class="C9Y-TabsContent C9Y--active"
       id="test-guid-three-content"
       role="tabpanel"
     >
@@ -89,7 +89,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="test-guid-four-action"
-      class="🅲TabsContent 🅲-active"
+      class="C9Y-TabsContent C9Y--active"
       id="test-guid-four-content"
       role="tabpanel"
     >

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -46,7 +46,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <button
       aria-controls="test-guid-four-content"
       aria-selected="false"
-      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction C9Y--disabled C9Y--disabled"
+      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction C9Y-disabled C9Y-disabled"
       data-active-id="four"
       disabled=""
       id="test-guid-four-tab"
@@ -62,7 +62,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <div
       aria-hidden="false"
       aria-labelledby="test-guid-one-action"
-      class="C9Y-TabsContent C9Y--active"
+      class="C9Y-TabsContent C9Y-active"
       id="test-guid-one-content"
       role="tabpanel"
     >
@@ -71,7 +71,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="test-guid-two-action"
-      class="C9Y-TabsContent C9Y--active"
+      class="C9Y-TabsContent C9Y-active"
       id="test-guid-two-content"
       role="tabpanel"
     >
@@ -80,7 +80,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="test-guid-three-action"
-      class="C9Y-TabsContent C9Y--active"
+      class="C9Y-TabsContent C9Y-active"
       id="test-guid-three-content"
       role="tabpanel"
     >
@@ -89,7 +89,7 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="test-guid-four-action"
-      class="C9Y-TabsContent C9Y--active"
+      class="C9Y-TabsContent C9Y-active"
       id="test-guid-four-content"
       role="tabpanel"
     >

--- a/src/components/Tabs/_tabs.scss
+++ b/src/components/Tabs/_tabs.scss
@@ -5,18 +5,18 @@
 //
 
 // --- Structure
-// .🅲-tabs
-// .🅲-tabs-actions-container
-// .🅲-tabs-action
-// .🅲-tabs-content-container
-// .🅲-tabs-content
+// .C9Y--tabs
+// .C9Y--tabs-actions-container
+// .C9Y--tabs-action
+// .C9Y--tabs-content-container
+// .C9Y--tabs-content
 
 //
 // Tabs container
 //
 
 // Container handles: margin between tabs and panes, and layout of tabs
-.🅲-tabs-actions-container {
+.C9Y--tabs-actions-container {
   display: flex;
   margin: $tabs-nav-container-margin;
   border-bottom: $tabs-nav-container-border;
@@ -119,6 +119,6 @@
 // Tab content container
 //
 
-.🅲-tabs-content-container {
+.C9Y--tabs-content-container {
   padding: $tabs-pane-container-padding;
 }

--- a/src/components/Tabs/_tabs.scss
+++ b/src/components/Tabs/_tabs.scss
@@ -5,18 +5,18 @@
 //
 
 // --- Structure
-// .C9Y--tabs
-// .C9Y--tabs-actions-container
-// .C9Y--tabs-action
-// .C9Y--tabs-content-container
-// .C9Y--tabs-content
+// .C9Y-tabs
+// .C9Y-tabs-actions-container
+// .C9Y-tabs-action
+// .C9Y-tabs-content-container
+// .C9Y-tabs-content
 
 //
 // Tabs container
 //
 
 // Container handles: margin between tabs and panes, and layout of tabs
-.C9Y--tabs-actions-container {
+.C9Y-tabs-actions-container {
   display: flex;
   margin: $tabs-nav-container-margin;
   border-bottom: $tabs-nav-container-border;
@@ -119,6 +119,6 @@
 // Tab content container
 //
 
-.C9Y--tabs-content-container {
+.C9Y-tabs-content-container {
   padding: $tabs-pane-container-padding;
 }

--- a/src/components/Text/Text.spec.js
+++ b/src/components/Text/Text.spec.js
@@ -31,7 +31,7 @@ describe('Text', () => {
     render(<Text variant='rad'>Componentry</Text>)
 
     expect(screen.getByText('Componentry')).toContainHTML(
-      '<section class="🅲Text-base 🅲Text-rad">Componentry</section>',
+      '<section class="C9Y-Text-base C9Y-Text-rad">Componentry</section>',
     )
   })
 })

--- a/src/components/Text/Text.styles.ts
+++ b/src/components/Text/Text.styles.ts
@@ -8,22 +8,22 @@ const { theme } = getMergedConfig()
 
 export const textStyles: TextStyles = {
   // BASE
-  '.🅲Text-base': {},
+  '.C9Y-Text-base': {},
 
   // VARIANTS
-  '.🅲Text-h1': {
+  '.C9Y-Text-h1': {
     fontSize: theme.fontSize.h1,
     color: theme.colors.gray[900],
   },
-  '.🅲Text-h2': {
+  '.C9Y-Text-h2': {
     fontSize: theme.fontSize.h2,
     color: theme.colors.gray[900],
   },
-  '.🅲Text-h3': {
+  '.C9Y-Text-h3': {
     fontSize: theme.fontSize.h3,
     color: theme.colors.gray[900],
   },
-  '.🅲Text-body': {
+  '.C9Y-Text-body': {
     fontSize: theme.fontSize.body,
     color: theme.colors.gray[800],
 
@@ -38,15 +38,15 @@ export const textStyles: TextStyles = {
 /** @public */
 export type TextStyles = {
   /** Base class applied to all variants for shared structural styles */
-  '.🅲Text-base': StylesDefinition
+  '.C9Y-Text-base': StylesDefinition
   /** Variant class applied when `variant="h1"` */
-  '.🅲Text-h1': StylesDefinition
+  '.C9Y-Text-h1': StylesDefinition
   /** Variant class applied when `variant="h2"` */
-  '.🅲Text-h2': StylesDefinition
+  '.C9Y-Text-h2': StylesDefinition
   /** Variant class applied when `variant="h3"` */
-  '.🅲Text-h3': StylesDefinition
+  '.C9Y-Text-h3': StylesDefinition
   /** Variant class applied when `variant="body"` */
-  '.🅲Text-body': {
+  '.C9Y-Text-body': {
     /** Sibling selector for auto-spacing multiple body elements */
     '& + &': StylesDefinition
   } & StylesDefinition

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -60,7 +60,7 @@ export const Text: FC<TextProps> = (props) => {
 
   return element({
     as: textElementMap[variant],
-    componentCx: `🅲Text-base 🅲Text-${variant}`,
+    componentCx: `C9Y-Text-base C9Y-Text-${variant}`,
     ...rest,
   })
 }

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Text /> snapshots renders correctly 1`] = `
 <p
-  class="🅲Text-base 🅲Text-body"
+  class="C9Y-Text-base C9Y-Text-body"
 >
   Componentry
 </p>

--- a/src/components/Tooltip/Tooltip.styles.ts
+++ b/src/components/Tooltip/Tooltip.styles.ts
@@ -25,7 +25,7 @@ export const tooltipStyles = {
     opacity: 0,
     transition: 'opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
 
-    '&.C9Y--active': {
+    '&.C9Y-active': {
       opacity: 1,
     },
   },

--- a/src/components/Tooltip/Tooltip.styles.ts
+++ b/src/components/Tooltip/Tooltip.styles.ts
@@ -9,29 +9,29 @@ const { theme } = getMergedConfig()
 const tooltipArrowWidth = 10 // in pixels
 
 export const tooltipStyles = {
-  '.🅲Tooltip-base': {
+  '.C9Y-Tooltip-base': {
     display: 'inline-block',
     position: 'relative',
   },
 
   // --- ACTION
-  '.🅲TooltipAction': {},
+  '.C9Y-TooltipAction': {},
 
   // --- CONTENT POSITIONER
-  '.🅲TooltipContent': {
+  '.C9Y-TooltipContent': {
     // Content container overrides the width constraints for parent element
     width: '300px',
     position: 'absolute',
     opacity: 0,
     transition: 'opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
 
-    '&.🅲-active': {
+    '&.C9Y--active': {
       opacity: 1,
     },
   },
 
   // --- CONTENT
-  '.🅲TooltipContentContents': {
+  '.C9Y-TooltipContentContents': {
     backgroundColor: theme.colors.gray[800],
     borderRadius: theme.borderRadius.md,
     color: theme.colors.inverse,
@@ -46,7 +46,7 @@ export const tooltipStyles = {
   },
 
   // --- ARROW
-  '.🅲TooltipContentArrow': {
+  '.C9Y-TooltipContentArrow': {
     height: tooltipArrowWidth * 2 + 'px',
     left: '0.5rem',
     overflow: 'hidden',

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -73,8 +73,8 @@ function TooltipContentElement({
 }) {
   return (
     <div {...rest}>
-      {renderArrow && <div className='🅲TooltipContentArrow' />}
-      <div className='🅲TooltipContentContents'>{children}</div>
+      {renderArrow && <div className='C9Y-TooltipContentArrow' />}
+      <div className='C9Y-TooltipContentContents'>{children}</div>
     </div>
   )
 }

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -2,28 +2,28 @@
 
 exports[`<Tooltip /> snapshots renders correctly 1`] = `
 <div
-  class="🅲Tooltip-base"
+  class="C9Y-Tooltip-base"
   data-id="test-guid"
   data-testid="tooltip"
 >
   <button
     aria-describedby="test-guid"
-    class="🅲Link-base 🅲Link-text 🅲TooltipAction"
+    class="C9Y-Link-base C9Y-Link-text C9Y-TooltipAction"
     type="button"
   >
     Action
   </button>
   <div
     aria-hidden="true"
-    class="🅲TooltipContent"
+    class="C9Y-TooltipContent"
     id="test-guid"
     role="tooltip"
   >
     <div
-      class="🅲TooltipContentArrow"
+      class="C9Y-TooltipContentArrow"
     />
     <div
-      class="🅲TooltipContentContents"
+      class="C9Y-TooltipContentContents"
     >
       Content
     </div>

--- a/src/plugin-babel/__fixtures__/as-prop/output.js
+++ b/src/plugin-babel/__fixtures__/as-prop/output.js
@@ -8,7 +8,7 @@ export default function Test() {
   return /*#__PURE__*/ _jsx('main', {
     className: 'flex',
     children: /*#__PURE__*/ _jsx(FancyText, {
-      className: '\uD83C\uDD72Text-base \uD83C\uDD72Text-body mt-md',
+      className: 'C9Y-Text-base C9Y-Text-body mt-md',
       fancy: true,
       children: 'Precompiled for speed',
     }),

--- a/src/plugin-babel/__fixtures__/data-precompiled/output.js
+++ b/src/plugin-babel/__fixtures__/data-precompiled/output.js
@@ -7,7 +7,7 @@ export default function Test() {
     className: 'flex',
     'data-component': 'Flex',
     children: /*#__PURE__*/ _jsx('p', {
-      className: '\uD83C\uDD72Text-base \uD83C\uDD72Text-body',
+      className: 'C9Y-Text-base C9Y-Text-body',
       'data-component': 'Text',
       children: 'Precompiled for speed',
     }),

--- a/src/plugin-babel/__fixtures__/expression-containers/output.js
+++ b/src/plugin-babel/__fixtures__/expression-containers/output.js
@@ -13,11 +13,11 @@ export default function Test({ success, position }) {
     className: 'flex',
     children: [
       /*#__PURE__*/ _jsx('p', {
-        className: '\uD83C\uDD72Text-base \uD83C\uDD72Text-body pt-80',
+        className: 'C9Y-Text-base C9Y-Text-body pt-80',
         children: 'Expression containers test',
       }),
       /*#__PURE__*/ _jsx('p', {
-        className: '\uD83C\uDD72Text-base \uD83C\uDD72Text-body font-bold',
+        className: 'C9Y-Text-base C9Y-Text-body font-bold',
         children: 'Expression containers test',
       }),
       /*#__PURE__*/ _jsx(Text, {

--- a/src/plugin-babel/__fixtures__/passthrough-props/output.js
+++ b/src/plugin-babel/__fixtures__/passthrough-props/output.js
@@ -9,12 +9,12 @@ export default function Test() {
     className: 'flex',
     children: [
       /*#__PURE__*/ _jsx('p', {
-        className: '\uD83C\uDD72Text-base \uD83C\uDD72Text-body',
+        className: 'C9Y-Text-base C9Y-Text-body',
         'data-skip': 'passthrough',
         children: 'Passthrough props',
       }),
       /*#__PURE__*/ _jsx('p', {
-        className: '\uD83C\uDD72Text-base \uD83C\uDD72Text-body',
+        className: 'C9Y-Text-base C9Y-Text-body',
         onMouseEnter: () => console.log('mouse_enter'),
         children: 'Passthrough props',
       }),

--- a/src/plugin-babel/__fixtures__/spread-attribute/output.js
+++ b/src/plugin-babel/__fixtures__/spread-attribute/output.js
@@ -8,7 +8,7 @@ export default function Test(props) {
     justify: 'center',
     ...props,
     children: /*#__PURE__*/ _jsx('p', {
-      className: '\uD83C\uDD72Text-base \uD83C\uDD72Text-body',
+      className: 'C9Y-Text-base C9Y-Text-body',
       children: 'Precompile testing',
     }),
   })

--- a/src/test/activation-tests.js
+++ b/src/test/activation-tests.js
@@ -20,7 +20,7 @@ export function activationTests(TestComponent, { name, testArias } = {}) {
    */
   it('should include size class for container', () => {
     const { container } = render(<TestComponent size='sm' />)
-    expect(container.firstChild).toHaveClass(`🅲${name}-smSize`)
+    expect(container.firstChild).toHaveClass(`C9Y-${name}-smSize`)
   })
 
   /**
@@ -28,7 +28,7 @@ export function activationTests(TestComponent, { name, testArias } = {}) {
    */
   it('should include direction class for container', () => {
     const { container } = render(<TestComponent direction='overlay' />)
-    expect(container.firstChild).toHaveClass(`🅲${name}-overlay`)
+    expect(container.firstChild).toHaveClass(`C9Y-${name}-overlay`)
   })
 
   /**

--- a/src/theme-defaults.ts
+++ b/src/theme-defaults.ts
@@ -2,7 +2,6 @@
  * -------------------------------------------------------------------------- */
 
 export const theme = {
-  prefix: '🅲-',
   // --- SCREENS
   // screens: {
   //   Componentry has a single breakpoint by default, additional breakpoints can

--- a/src/utils/active-action-component-builder.tsx
+++ b/src/utils/active-action-component-builder.tsx
@@ -45,7 +45,7 @@ export function activeActionBuilder<TProps extends ActiveActionBaseProps>(
 
     return element({
       as: defaultAs,
-      componentCx: `🅲${displayName}`,
+      componentCx: `C9Y-${displayName}`,
       ...computeARIA({
         active,
         activeId,

--- a/src/utils/active-container-component-builder.tsx
+++ b/src/utils/active-container-component-builder.tsx
@@ -213,10 +213,10 @@ export function activeContainerBuilder<TProps extends ActiveContainerBaseProps>(
         {element({
           'data-id': guid,
           componentCx: [
-            `🅲${displayName}-base`,
+            `C9Y-${displayName}-base`,
             {
-              [`🅲${displayName}-${size}Size`]: size,
-              [`🅲${displayName}-${direction}`]: direction,
+              [`C9Y-${displayName}-${size}Size`]: size,
+              [`C9Y-${displayName}-${direction}`]: direction,
             },
           ],
           // For elements with mouse events we need to know when the mouse event

--- a/src/utils/active-content-component-builder.tsx
+++ b/src/utils/active-content-component-builder.tsx
@@ -40,7 +40,7 @@ export function activeContentBuilder<TProps extends ActiveContentBaseProps>(
     return element({
       as: defaultAs,
       active: visible,
-      componentCx: `🅲${displayName}`,
+      componentCx: `C9Y-${displayName}`,
       ...computeARIA({
         active,
         activeId,

--- a/src/utils/static-component-builder.tsx
+++ b/src/utils/static-component-builder.tsx
@@ -19,7 +19,7 @@ export function staticComponent<Props>(
 ): React.FC<Props> {
   function Component(props: Props) {
     return element({
-      componentCx: `🅲${displayName}`,
+      componentCx: `C9Y-${displayName}`,
       ...defaultProps,
       ...useTheme<Props>(displayName),
       ...props,

--- a/src/utils/utility-classes.ts
+++ b/src/utils/utility-classes.ts
@@ -286,8 +286,8 @@ function generateClassNames<Props extends UtilityProps>(p: Props): string {
     [`border-${p.borderColor}`]: p.borderColor,
 
     // STATES (eg https://mui.com/customization/how-to-customize/#state-classes)
-    '🅲-active': p.active,
-    '🅲-disabled': p.disabled,
+    'C9Y--active': p.active,
+    'C9Y--disabled': p.disabled,
   })
 }
 

--- a/src/utils/utility-classes.ts
+++ b/src/utils/utility-classes.ts
@@ -286,8 +286,8 @@ function generateClassNames<Props extends UtilityProps>(p: Props): string {
     [`border-${p.borderColor}`]: p.borderColor,
 
     // STATES (eg https://mui.com/customization/how-to-customize/#state-classes)
-    'C9Y--active': p.active,
-    'C9Y--disabled': p.disabled,
+    'C9Y-active': p.active,
+    'C9Y-disabled': p.disabled,
   })
 }
 


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Changes the default class prefix to something easier to type out._

### Notes

- This is intended to be a convenience since finding the 🅲 emoji isn't easy.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
