### PR TITLE
Upgrade package export definitions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,11 @@
 .prettierrc.js
 node_modules
 
+# CommonJS entry files
+# -------------------------------------
+src/plugin-babel/index.ts
+src/plugin-postcss/index.ts
+
 # Babel plugin fixtures aren't fully valid
 # -------------------------------------
 src/plugin-babel/__fixtures__

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@
 # -------------------------------------
 
 .prettierrc.js
+postcss.config.js
 node_modules
 
 # CommonJS entry files

--- a/babel.js
+++ b/babel.js
@@ -1,8 +1,0 @@
-/* eslint-disable */
-
-/**
- * ℹ️ This is the Babel plugin entry file, it uses the CommonJS compiled assets
- * after publishing. For local development of the Babel plugin use the plugin
- * test file with `npx jest src/plugin`
- */
-module.exports = require('./dist/commonjs/plugin-babel/plugin')

--- a/docs/publishing.stories.mdx
+++ b/docs/publishing.stories.mdx
@@ -4,6 +4,15 @@ import { Meta } from '@storybook/addon-docs'
 
 # Publishing notes
 
+### package.json fields
+
+1. `exports` provides the 'modern' way to explicitly define exports, and has the advantage
+   of being able to define a set of mapped paths for cleaner imports by users. It is the
+   preferred field and is supported by webpack.
+2. `main` and `module` are included for tools that don't support `exports` yet, which
+   includes `eslint-plugin-import`.
+3. `types` defines the type definitions path.
+
 ### Babel compilation
 
 Source code is compiled using `preset-env` to ensure that any modern syntax is compiled to

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "license": "MIT",
   "exports": {
-    "./babel": "./babel.js",
-    "./postcss": "./postcss.js",
+    "./babel": "./dist/commonjs/plugin-babel/index.js",
+    "./postcss": "./dist/commonjs/plugin-postcss/index.js",
     "./api-docs": "./dist/api-docs.json",
     ".": {
       "browser": "./dist/browser/index.js",
@@ -33,6 +33,8 @@
       "default": "./dist/browser/index.js"
     }
   },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/browser/index.js",
   "types": "./types/index.d.ts",
   "sideEffects": false,
   "scripts": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,9 @@
 
 module.exports = {
   plugins: [
-    require('./postcss'), // development entry for Componentry plugin
+    // internal development entry for Componentry plugin, when published this is:
+    // require('componentry/postcss')
+    require('./dist/commonjs/plugin-postcss/index'),
     require('tailwindcss'),
     require('autoprefixer'),
   ],

--- a/postcss.js
+++ b/postcss.js
@@ -1,7 +1,0 @@
-/* eslint-disable */
-
-/**
- * ℹ️ This is the PostCSS plugin entry file, it uses the CommonJS compiled
- * assets after publishing.
- */
-module.exports = require('./dist/commonjs/plugin-postcss/plugin').plugin

--- a/src/plugin-babel/index.ts
+++ b/src/plugin-babel/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Componentry components pre-compile Babel plugin entry
+ */
+module.exports = require('./plugin')

--- a/src/plugin-postcss/index.ts
+++ b/src/plugin-postcss/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Componentry PostCSS plugin entry
+ */
+module.exports = require('./plugin').plugin

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,9 @@
   },
 
   "include": ["@types/**/*", "src/**/*"],
-  "exclude": ["src/**/*.spec.js"]
+  "exclude": [
+    "src/plugin-postcss/index.ts",
+    "src/plugin-babel/index.ts",
+    "src/**/*.spec.js"
+  ]
 }


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Improvements to the package export definitions_

### Notes

- Turns out getting all of the export configurations right is tricky 😄 
- Adds back `main` and `module` for backwards compat, `eslint-plugin-import` needs them.
- Figured out a way to include Babel/PostCSS plugin entries in their src folders
