### PR TITLE
Use switch statement for perf in createUtilityClasses

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   // Provides nice test output of what's being run
   verbose: true,
 
-  // OS notifications of test results is an opt in for funesies
+  // OS notifications of test results is an opt in for funsies
   notify: Boolean(ENABLE_JEST_NOTIFICATIONS),
 
   // Test coverage can be enforced with a coverageThreshold
@@ -17,6 +17,7 @@ module.exports = {
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
     '!**/*.stories.js', // Ignore story files
+    '!src/benchmarks/**', // Ignore perf testing files
     '!src/{Media,Modal,Theme}/stories/**', // Ignore story files
     '!**/*.styles.ts', // Ignore PostCSS styles
     '!src/test/**', // Ignore test files

--- a/src/benchmarks/utility-classes.benchmark.ts
+++ b/src/benchmarks/utility-classes.benchmark.ts
@@ -1,0 +1,75 @@
+/* eslint-disable no-plusplus, no-console */
+import { createUtilityClasses } from '../utils/utility-classes'
+import { createUtilityClasses as v1CreateUtilityClasses } from './v1-utility-classes'
+
+console.log('--- V1 createUtilityClasses ---')
+const v1start = performance.now()
+const v1largeStart = performance.now()
+for (let i = 0; i < 100000; i++) {
+  v1CreateUtilityClasses({
+    alignItems: 'stretch',
+    bold: true,
+    color: 'body',
+    direction: 'column',
+    display: 'block',
+    gap: 3,
+    lineHeight: 'snug',
+    minHeight: 'screen',
+    mt: 3,
+    visible: true,
+    dataselected: true,
+    datatest: 'custom',
+  })
+}
+const v1largeEnd = performance.now()
+
+const v1smallStart = performance.now()
+for (let i = 0; i < 100000; i++) {
+  v1CreateUtilityClasses({
+    display: 'block',
+    mt: 3,
+    datatest: 'custom',
+  })
+}
+const v1smallEnd = performance.now()
+const v1end = performance.now()
+
+console.log(`Large set time: ${v1largeEnd - v1largeStart}`)
+console.log(`Small set time: ${v1smallEnd - v1smallStart}`)
+console.log(`Total time: ${v1end - v1start}`)
+
+console.log('--- V2 createUtilityClasses ---')
+const v2start = performance.now()
+const v2largeStart = performance.now()
+for (let i = 0; i < 100000; i++) {
+  createUtilityClasses({
+    alignItems: 'stretch',
+    bold: true,
+    color: 'body',
+    direction: 'column',
+    display: 'block',
+    gap: 3,
+    lineHeight: 'snug',
+    minHeight: 'screen',
+    mt: 3,
+    visible: true,
+    dataselected: true,
+    datatest: 'custom',
+  })
+}
+const v2largeEnd = performance.now()
+
+const v2smallStart = performance.now()
+for (let i = 0; i < 100000; i++) {
+  createUtilityClasses({
+    display: 'block',
+    mt: 3,
+    datatest: 'custom',
+  })
+}
+const v2smallEnd = performance.now()
+const v2end = performance.now()
+
+console.log(`Large set time: ${v2largeEnd - v2largeStart}`)
+console.log(`Small set time: ${v2smallEnd - v2smallStart}`)
+console.log(`V2 Total time: ${v2end - v2start}`)

--- a/src/benchmarks/v1-utility-classes.ts
+++ b/src/benchmarks/v1-utility-classes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-template */
 /**
  * @file
  * Resource for cleaning Componentry props and creating utility classes.
@@ -8,7 +7,8 @@
  * `declare module 'componentry/types/utils/utility-classes' { }`
  */
 
-import { MergePropTypes } from './types'
+import clsx from 'clsx'
+import { MergePropTypes } from '../utils/types'
 
 /** Module augmentation interface for overriding default utility props' types */
 export interface UtilityPropsOverrides {}
@@ -143,6 +143,64 @@ export interface UtilityPropsBase {
 /** Componentry utility props for including utility styles. */
 export type UtilityProps = MergePropTypes<UtilityPropsBase, UtilityPropsOverrides>
 
+// Map of utility props for quickly filtering out Componentry props from user props
+export const utilityProps: { [Prop in keyof UtilityPropsBase]: 1 } = {
+  active: 1,
+  alignContent: 1,
+  alignItems: 1,
+  alignSelf: 1,
+  backgroundColor: 1,
+  bold: 1,
+  border: 1,
+  borderBottom: 1,
+  borderColor: 1,
+  borderLeft: 1,
+  borderRight: 1,
+  borderTop: 1,
+  color: 1,
+  disabled: 1,
+  display: 1,
+  flexDirection: 1,
+  flexWrap: 1,
+  fontFamily: 1,
+  fontSize: 1,
+  fontWeight: 1,
+  gap: 1,
+  'gap-x': 1,
+  'gap-y': 1,
+  height: 1,
+  invisible: 1,
+  italic: 1,
+  justifyContent: 1,
+  justifyItems: 1,
+  justifySelf: 1,
+  letterSpacing: 1,
+  lineHeight: 1,
+  m: 1,
+  maxHeight: 1,
+  maxWidth: 1,
+  mb: 1,
+  minHeight: 1,
+  minWidth: 1,
+  ml: 1,
+  mr: 1,
+  mt: 1,
+  mx: 1,
+  my: 1,
+  p: 1,
+  pb: 1,
+  pl: 1,
+  position: 1,
+  pr: 1,
+  pt: 1,
+  px: 1,
+  py: 1,
+  textAlign: 1,
+  textTransform: 1,
+  visible: 1,
+  width: 1,
+}
+
 const activeProps = {
   activate: 1,
   deactivate: 1,
@@ -152,6 +210,85 @@ const activeProps = {
   onActivated: 1,
   onDeactivate: 1,
   onDeactivated: 1,
+}
+
+function generateClassNames<Props extends UtilityProps>(p: Props): string {
+  // Tailwind expects a `flex-col` for direction which breaks the pattern of specifying
+  // the style value
+  const computedDir = p.flexDirection?.replace('column', 'col')
+  // Support shorthand bold everywhere to match shorthand italic for easy text styles
+  const computedFontWeight = p.bold ? 'bold' : p.fontWeight
+  return clsx({
+    // LAYOUT
+    [p.position ?? 'position']: p.position,
+    [p.display ?? 'display']: p.display,
+    invisible: p.invisible,
+    visible: p.visible,
+
+    // FLEXBOX+GRID
+    [`content-${p.alignContent}`]: p.alignContent,
+    [`flex-${computedDir}`]: computedDir,
+    [`flex-${p.flexWrap}`]: p.flexWrap,
+    [`items-${p.alignItems}`]: p.alignItems,
+    [`justify-${p.justifyContent}`]: p.justifyContent,
+    [`justify-items-${p.justifyItems}`]: p.justifyItems,
+    [`justify-${p.justifySelf}`]: p.justifySelf,
+    [`self-${p.alignSelf}`]: p.alignSelf,
+
+    // SPACING
+    [`m-${p.m}`]: p.m,
+    [`mt-${p.mt}`]: p.mt,
+    [`mr-${p.mr}`]: p.mr,
+    [`mb-${p.mb}`]: p.mb,
+    [`ml-${p.ml}`]: p.ml,
+    [`mx-${p.mx}`]: p.mx,
+    [`my-${p.my}`]: p.my,
+    [`p-${p.p}`]: p.p,
+    [`pt-${p.pt}`]: p.pt,
+    [`pr-${p.pr}`]: p.pr,
+    [`pb-${p.pb}`]: p.pb,
+    [`pl-${p.pl}`]: p.pl,
+    [`px-${p.px}`]: p.px,
+    [`py-${p.py}`]: p.py,
+    [`gap-${p.gap}`]: p.gap,
+    [`gap-x-${p['gap-x']}`]: p['gap-x'],
+    [`gap-y-${p['gap-y']}`]: p['gap-y'],
+
+    // SIZING
+    [`h-${p.height}`]: p.height,
+    [`min-h-${p.minHeight}`]: p.minHeight,
+    [`max-h-${p.maxHeight}`]: p.maxHeight,
+    [`w-${p.width}`]: p.width,
+    [`min-w-${p.minWidth}`]: p.minWidth,
+    [`max-w-${p.maxWidth}`]: p.maxWidth,
+
+    // TYPOGRAPHY
+    [p.textTransform ?? 'textTransform']: p.textTransform,
+    [`font-${p.fontFamily}`]: p.fontFamily,
+    [`font-${computedFontWeight}`]: computedFontWeight,
+    [`leading-${p.lineHeight}`]: p.lineHeight,
+    [`text-${p.color}`]: p.color,
+    [`text-${p.fontSize}`]: p.fontSize,
+    [`text-${p.textAlign}`]: p.textAlign,
+    [`tracking-${p.letterSpacing}`]: p.letterSpacing,
+    italic: p.italic,
+
+    // BACKGROUNDS
+    [`bg-${p.backgroundColor}`]: p.backgroundColor,
+
+    // BORDERS
+    border: p.border, // 1px borderWidth
+    'border-b': p.borderBottom, // 1px borderWidth
+    'border-l': p.borderLeft, // 1px borderWidth
+    'border-r': p.borderRight, // 1px borderWidth
+    'border-t': p.borderTop, // 1px borderWidth
+    [`border-${p.borderWidth}`]: p.borderWidth,
+    [`border-${p.borderColor}`]: p.borderColor,
+
+    // STATES (eg https://mui.com/customization/how-to-customize/#state-classes)
+    'C9Y-active': p.active,
+    'C9Y-disabled': p.disabled,
+  })
 }
 
 /**
@@ -171,205 +308,35 @@ export function createUtilityClasses<Props extends { [prop: string]: any }>(
   props: Props,
 ) {
   const filteredProps: { [prop: string]: any } = {}
-  const classes: string[] = []
+
+  // Pass through disabled to final element as it's a valid HTML attribute
+  if (props.disabled) filteredProps.disabled = true
 
   Object.keys(props).forEach((prop) => {
-    const value = props[prop]
-    // If a props has a key, but the prop value is undefined or false we can bail early
-    if (value === undefined || value === false) return
-
-    switch (prop) {
-      // LAYOUT
-      case 'position':
-      case 'display':
-        classes.push(value)
-        break
-      case 'invisible':
-        classes.push('invisible')
-        break
-      case 'visible':
-        classes.push('visible')
-        break
-
-      // FLEXBOX/GRID
-      case 'alignContent':
-        classes.push('content-' + value)
-        break
-      case 'flexDirection':
-        classes.push('flex-' + value.replace('column', 'col'))
-        break
-      case 'flexWrap':
-        classes.push('flex-' + value)
-        break
-      case 'alignItems':
-        classes.push('items-' + value)
-        break
-      case 'justifyContent':
-        classes.push('justify-' + value)
-        break
-      case 'justifyItems':
-        classes.push('justify-items-' + value)
-        break
-      case 'justifySelf':
-        classes.push('justify-' + value)
-        break
-      case 'alignSelf':
-        classes.push('self-' + value)
-        break
-
-      // SPACING
-      case 'm':
-        classes.push('m-' + value)
-        break
-      case 'mt':
-        classes.push('mt-' + value)
-        break
-      case 'mr':
-        classes.push('mr-' + value)
-        break
-      case 'mb':
-        classes.push('mb-' + value)
-        break
-      case 'ml':
-        classes.push('ml-' + value)
-        break
-      case 'mx':
-        classes.push('mx-' + value)
-        break
-      case 'my':
-        classes.push('my-' + value)
-        break
-      case 'p':
-        classes.push('p-' + value)
-        break
-      case 'pt':
-        classes.push('pt-' + value)
-        break
-      case 'pr':
-        classes.push('pr-' + value)
-        break
-      case 'pb':
-        classes.push('pb-' + value)
-        break
-      case 'pl':
-        classes.push('pl-' + value)
-        break
-      case 'px':
-        classes.push('px-' + value)
-        break
-      case 'py':
-        classes.push('py-' + value)
-        break
-      case 'gap':
-        classes.push('gap-' + value)
-        break
-      case 'gap-x':
-        classes.push('gap-x-' + value)
-        break
-      case 'gap-y':
-        classes.push('gap-y-' + value)
-        break
-
-      // SIZING
-      case 'height':
-        classes.push('h-' + value)
-        break
-      case 'minHeight':
-        classes.push('min-h-' + value)
-        break
-      case 'maxHeight':
-        classes.push('max-h-' + value)
-        break
-      case 'width':
-        classes.push('w-' + value)
-        break
-      case 'minWidth':
-        classes.push('min-w-' + value)
-        break
-      case 'maxWidth':
-        classes.push('max-w-' + value)
-        break
-
-      // TYPOGRAPHY
-      case 'bold':
-        classes.push('font-bold')
-        break
-      case 'italic':
-        classes.push('italic')
-        break
-      case 'fontFamily':
-        classes.push('font-' + value)
-        break
-      case 'fontWeight':
-        classes.push('font-' + value)
-        break
-      case 'lineHeight':
-        classes.push('leading-' + value)
-        break
-      case 'color':
-        classes.push('text-' + value)
-        break
-      case 'fontSize':
-        classes.push('text-' + value)
-        break
-      case 'textAlign':
-        classes.push('text-' + value)
-        break
-      case 'letterSpacing':
-        classes.push('tracking-' + value)
-        break
-      case 'textTransform':
-        classes.push(value)
-        break
-
-      // BACKGROUNDS
-      case 'backgroundColor':
-        classes.push('bg-' + value)
-        break
-
-      // BORDERS
-      case 'border':
-        classes.push('border') // 1px borderWidth
-        break
-      case 'borderBottom':
-        classes.push('border-b') // 1px borderWidth
-        break
-      case 'borderLeft':
-        classes.push('border-l') // 1px borderWidth
-        break
-      case 'borderRight':
-        classes.push('border-r') // 1px borderWidth
-        break
-      case 'borderTop':
-        classes.push('border-t') // 1px borderWidth
-        break
-      case 'borderWidth':
-        classes.push('border-' + value)
-        break
-      case 'borderColor':
-        classes.push('border-' + value)
-        break
-
-      // STATES (eg https://mui.com/customization/how-to-customize/#state-classes)
-      case 'active':
-        classes.push('C9Y-active')
-        break
-      case 'disabled':
-        classes.push('C9Y-disabled')
-        // Pass through disabled to final element as it's a valid HTML attribute
-        filteredProps.disabled = true
-        break
-
-      default:
-        if (!(prop in activeProps)) {
-          // The prop doesn't map to a library utility prop, pass it through
-          filteredProps[prop] = props[prop]
-        }
+    if (!(prop in utilityProps) && !(prop in activeProps)) {
+      // The prop doesn't map to a library utility prop, pass it through
+      filteredProps[prop] = props[prop]
     }
   })
 
   return {
     filteredProps,
-    utilityClasses: classes.join(' '),
+    utilityClasses: generateClassNames(props),
   }
+}
+
+// --------------------------------------------------------
+// PRECOMPILE
+
+/** @internal */
+export const precompileProps = {
+  inline: 1,
+  variant: 1,
+  // --- Flex
+  align: 1,
+  direction: 1,
+  justify: 1,
+  wrap: 1,
+  // --- Text
+  bold: 1,
 }

--- a/src/plugin-babel/plugin.ts
+++ b/src/plugin-babel/plugin.ts
@@ -5,14 +5,79 @@ import { Flex } from '../components/Flex/Flex'
 import { Block } from '../components/Block/Block'
 import { Text } from '../components/Text/Text'
 import { initializePreCompileMode } from '../components/Theme/Theme'
-import { precompileProps, utilityProps } from '../utils/utility-classes'
 
 import { parseAttributes } from './parse-attributes'
 import { buildClosingElement, buildOpeningElement } from './build-elements'
 
 const components = { Block, Flex, Text }
 // These are the props that should be parsed to compute the component value
-const parseProps = { as: 1, className: 1, ...utilityProps, ...precompileProps }
+const parseProps = {
+  as: 1,
+  className: 1,
+  active: 1,
+  alignContent: 1,
+  alignItems: 1,
+  alignSelf: 1,
+  backgroundColor: 1,
+  bold: 1,
+  border: 1,
+  borderBottom: 1,
+  borderColor: 1,
+  borderLeft: 1,
+  borderRight: 1,
+  borderTop: 1,
+  color: 1,
+  disabled: 1,
+  display: 1,
+  flexDirection: 1,
+  flexWrap: 1,
+  fontFamily: 1,
+  fontSize: 1,
+  fontWeight: 1,
+  gap: 1,
+  'gap-x': 1,
+  'gap-y': 1,
+  height: 1,
+  invisible: 1,
+  italic: 1,
+  justifyContent: 1,
+  justifyItems: 1,
+  justifySelf: 1,
+  letterSpacing: 1,
+  lineHeight: 1,
+  m: 1,
+  maxHeight: 1,
+  maxWidth: 1,
+  mb: 1,
+  minHeight: 1,
+  minWidth: 1,
+  ml: 1,
+  mr: 1,
+  mt: 1,
+  mx: 1,
+  my: 1,
+  p: 1,
+  pb: 1,
+  pl: 1,
+  position: 1,
+  pr: 1,
+  pt: 1,
+  px: 1,
+  py: 1,
+  textAlign: 1,
+  textTransform: 1,
+  visible: 1,
+  width: 1,
+  // PRECOMPILE
+  inline: 1,
+  variant: 1,
+  // --- Flex
+  align: 1,
+  direction: 1,
+  justify: 1,
+  wrap: 1,
+  // --- Text
+}
 
 /*
  * # Types Notes

--- a/src/utils/utility-classes.spec.js
+++ b/src/utils/utility-classes.spec.js
@@ -1,57 +1,175 @@
 import { createUtilityClasses } from './utility-classes'
 
-const sizes = ['xs', 'sm', 'md', 'lg', 'xl']
-
 describe('createUtilityClasses()', () => {
-  it('computes spacing utility classes', () => {
-    sizes.forEach((size) => {
-      const computed = createUtilityClasses({ m: size, p: size })
+  it('does not compute undefined values', () => {
+    expect(createUtilityClasses({}).utilityClasses).toBe('')
+  })
 
-      expect(computed.utilityClasses.includes(`m-${size}`)).toBeTruthy()
-      expect(computed.utilityClasses.includes(`p-${size}`)).toBeTruthy()
+  it('computes layout classes', () => {
+    expect(
+      createUtilityClasses({
+        position: 'fixed',
+        display: 'grid',
+        invisible: true,
+        visible: true,
+      }).utilityClasses,
+    ).toBe('fixed grid invisible visible')
+
+    expect(
+      createUtilityClasses({
+        position: undefined,
+        display: undefined,
+        invisible: false,
+        visible: false,
+      }).utilityClasses,
+    ).toBe('')
+  })
+
+  it('computes spacing utility classes', () => {
+    const spacings = [0, 0.5, 1, 2, 3]
+    spacings.forEach((spacing) => {
+      const computed = createUtilityClasses({
+        m: spacing,
+        mt: spacing,
+        mr: spacing,
+        mb: spacing,
+        ml: spacing,
+        mx: spacing,
+        my: spacing,
+      })
+
+      expect(computed.utilityClasses).toBe(
+        `m-${spacing} mt-${spacing} mr-${spacing} mb-${spacing} ml-${spacing} mx-${spacing} my-${spacing}`,
+      )
+    })
+
+    spacings.forEach((spacing) => {
+      const computed = createUtilityClasses({
+        p: spacing,
+        pt: spacing,
+        pr: spacing,
+        pb: spacing,
+        pl: spacing,
+        px: spacing,
+        py: spacing,
+      })
+
+      expect(computed.utilityClasses).toBe(
+        `p-${spacing} pt-${spacing} pr-${spacing} pb-${spacing} pl-${spacing} px-${spacing} py-${spacing}`,
+      )
     })
   })
 
-  it('computes border utility classes', () => {
-    expect(createUtilityClasses({ border: true }).utilityClasses).toBe('border')
-
-    expect(createUtilityClasses({ borderTop: true }).utilityClasses).toBe('border-t')
-    expect(createUtilityClasses({ borderRight: true }).utilityClasses).toBe('border-r')
-    expect(createUtilityClasses({ borderBottom: true }).utilityClasses).toBe('border-b')
-    expect(createUtilityClasses({ borderLeft: true }).utilityClasses).toBe('border-l')
-
-    expect(createUtilityClasses({ borderWidth: 'lg' }).utilityClasses).toBe('border-lg')
-    expect(createUtilityClasses({ borderColor: 'primary' }).utilityClasses).toBe(
-      'border-primary',
-    )
-  })
-
-  it('computes all utility classes', () => {
+  it('computes sizing utility classes', () => {
     expect(
       createUtilityClasses({
-        alignContent: 'center',
-        alignItems: 'center',
-        alignSelf: 'center',
-        backgroundColor: 'primary',
-        border: true,
-        borderBottom: true,
-        borderColor: 'primary',
-        borderLeft: true,
-        borderRight: true,
-        borderTop: true,
-        borderWidth: 'lg',
-        color: 'primary',
-        fontFamily: 'monospace',
+        height: 'screen',
+        minHeight: 'screen',
+        maxHeight: 'screen',
+        width: 'full',
+        minWidth: 'full',
+        maxWidth: 'full',
+      }).utilityClasses,
+    ).toBe('h-screen min-h-screen max-h-screen w-full min-w-full max-w-full')
+
+    expect(
+      createUtilityClasses({
+        height: undefined,
+        minHeight: undefined,
+        maxHeight: undefined,
+        width: undefined,
+        minWidth: undefined,
+        maxWidth: undefined,
+      }).utilityClasses,
+    ).toBe('')
+  })
+
+  it('computes typography utility classes', () => {
+    expect(
+      createUtilityClasses({
+        bold: true,
+        italic: true,
+        fontFamily: 'mono',
+        fontWeight: 'normal',
+        lineHeight: 'none',
+        color: 'heading',
         fontSize: 'sm',
-        fontStyle: 'italic',
-        fontWeight: 'light',
-        justifyContent: 'center',
-        position: 'fixed',
         textAlign: 'center',
+        letterSpacing: 'tighter',
         textTransform: 'uppercase',
       }).utilityClasses,
     ).toBe(
-      'fixed content-center items-center justify-center self-center uppercase font-monospace font-light text-primary text-sm text-center bg-primary border border-b border-l border-r border-t border-lg border-primary',
+      'font-bold italic font-mono font-normal leading-none text-heading text-sm text-center tracking-tighter uppercase',
+    )
+
+    expect(
+      createUtilityClasses({
+        bold: false,
+        italic: false,
+        fontFamily: undefined,
+        fontWeight: undefined,
+        lineHeight: undefined,
+        color: undefined,
+        fontSize: undefined,
+        textAlign: undefined,
+        letterSpacing: undefined,
+        textTransform: undefined,
+      }).utilityClasses,
+    ).toBe('')
+  })
+
+  it('computes background color utility classes', () => {
+    expect(
+      createUtilityClasses({
+        backgroundColor: 'primary-100',
+      }).utilityClasses,
+    ).toBe('bg-primary-100')
+
+    expect(
+      createUtilityClasses({
+        backgroundColor: undefined,
+      }).utilityClasses,
+    ).toBe('')
+  })
+
+  it('computes border utility classes', () => {
+    expect(
+      createUtilityClasses({
+        border: true,
+        borderTop: true,
+        borderRight: true,
+        borderBottom: true,
+        borderLeft: true,
+        borderWidth: 'lg',
+        borderColor: 'primary',
+      }).utilityClasses,
+    ).toBe('border border-t border-r border-b border-l border-lg border-primary')
+
+    expect(
+      createUtilityClasses({
+        border: false,
+        borderTop: false,
+        borderRight: false,
+        borderBottom: false,
+        borderLeft: false,
+        borderWidth: undefined,
+        borderColor: undefined,
+      }).utilityClasses,
+    ).toBe('')
+  })
+
+  it('computes state classes', () => {
+    expect(createUtilityClasses({ active: true, disabled: true }).utilityClasses).toBe(
+      'C9Y-active C9Y-disabled',
+    )
+    expect(
+      createUtilityClasses({ active: true, disabled: true }).filteredProps,
+    ).toStrictEqual({
+      disabled: true,
+    })
+
+    expect(createUtilityClasses({ active: false, disabled: false }).utilityClasses).toBe(
+      '',
     )
   })
 })


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

Replaces the mechanism for computing utility classes: Switches from using an object with `clsx` to a switch statement. Overall result is _MUCH_ faster 🏎️ 

### Notes

Benchmark performance in ms

| V1: Object w/ clsx |        |        | V2: Switch       |                  |                  |
| ------------------ | ------ | ------ | ---------------- | ---------------- | ---------------- |
| Large              | Small  | Total  | Large            | Small            | Total            |
| 1627               | 1533   | 3161   | 116              | 32               | 148              |
| 1644               | 1528   | 3172   | 105              | 29               | 134              |
| 1667               | 1516   | 3184   | 104              | 29               | 133              |
| 1632               | 1565   | 3198   | 110              | 29               | 139              |
| 1647               | 1571   | 3219   | 107              | 35               | 142              |
| 1643.4             | 1542.6 | 3186.8 | 108.4            | 30.8             | 139.2            |
|                    |        |        | 15.1605166051661 | 50.0844155844156 | 22.8936781609195 |
|                    |        |        | ~15x faster      | ~50x faster      | ~23x faster      |




<!-- Thank you for contributing, you are AWESOME 🥳 -->
