### PR TITLE
Update: Use passed theme directly for PostCSS

### DIFF
--- a/src/plugin-postcss/configs.ts
+++ b/src/plugin-postcss/configs.ts
@@ -12,7 +12,7 @@ const configSearchResults = explorerSync.search()
 const userConfig = configSearchResults?.config ?? {}
 
 const mergedConfig = {
-  theme: createTheme(userConfig.theme ?? {}),
+  theme: userConfig.theme ?? createTheme(),
   components: userConfig.components ?? {},
   foundation: userConfig.foundation ?? {},
 }


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Updates the PostCSS plugin to use the passed theme directly._


### Notes


This consolidates theme definition for users to a single location, preferably using `createTheme`, and then using that same created theme value for the PostCSS plugin as well as the runtime `useTheme`.
