### PR TITLE
New: Provide ref-able layout components

### DIFF
--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -1,4 +1,4 @@
-import { type FC } from 'react'
+import { type FC, forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
@@ -17,11 +17,29 @@ export interface BlockProps extends ComponentBaseProps<'div'> {}
  * ```
  */
 export const Block: FC<BlockProps> = (props) => {
-  const rest = {
+  return element({
     ...useThemeProps('Block'),
     ...props,
-  }
-
-  return element(rest)
+  })
 }
 Block.displayName = 'Block'
+
+/**
+ * **[📝 RefBlock docs](https://componentry.design/docs/components/block)**
+ *
+ * `RefBlock` provides a ref-able `Block` element.
+ * @example
+ * ```tsx
+ * <RefBlock ref={ref} mt={2} mx={3}>
+ *   ...
+ * </RefBlock>
+ * ```
+ */
+export const RefBlock = forwardRef<HTMLDivElement, BlockProps>((props, ref) => {
+  return element({
+    ref,
+    ...useThemeProps('Block'),
+    ...props,
+  })
+})
+RefBlock.displayName = 'RefBlock'

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,4 +1,5 @@
-import { type FC } from 'react'
+/* eslint-disable react/no-unused-prop-types */
+import { type FC, forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
@@ -44,3 +45,32 @@ export const Flex: FC<FlexProps> = (props) => {
   })
 }
 Flex.displayName = 'Flex'
+
+/**
+ * **[📝 RefFlex docs](https://componentry.design/docs/components/flex)**
+ *
+ * `RefFlex` provides a ref-able `Flex` element.
+ * @example
+ * ```tsx
+ * <RefFlex ref={ref} align="center" gap={2}>
+ *   ...
+ * </RefFlex>
+ * ```
+ */
+export const RefFlex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
+  const { align, direction, justify, wrap, ...rest } = {
+    ...useThemeProps('Flex'),
+    ...props,
+  }
+
+  return element({
+    ref,
+    display: 'flex',
+    alignItems: align,
+    flexDirection: direction,
+    flexWrap: wrap,
+    justifyContent: justify,
+    ...rest,
+  })
+})
+RefFlex.displayName = 'RefFlex'

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,4 +1,5 @@
-import { type FC } from 'react'
+/* eslint-disable react/no-unused-prop-types */
+import { type FC, forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
@@ -19,9 +20,9 @@ export type GridProps = GridPropsBase & ComponentBaseProps<'div'>
  * utility props.
  * @example
  * ```tsx
- * <Flex gap={2}>
+ * <Grid gap={2}>
  *   ...
- * </Flex>
+ * </Grid>
  * ```
  */
 export const Grid: FC<GridProps> = (props) => {
@@ -38,3 +39,30 @@ export const Grid: FC<GridProps> = (props) => {
   })
 }
 Grid.displayName = 'Grid'
+
+/**
+ * **[📝 Grid docs](https://componentry.design/docs/components/grid)**
+ *
+ * `Grid` provides a ref-able `Grid` element.
+ * @example
+ * ```tsx
+ * <RefGrid ref={ref} gap={2}>
+ *   ...
+ * </RefGrid>
+ * ```
+ */
+export const RefGrid = forwardRef<HTMLDivElement, GridProps>((props, ref) => {
+  const { align, justify, ...rest } = {
+    ...useThemeProps('Grid'),
+    ...props,
+  }
+
+  return element({
+    ref,
+    display: 'grid',
+    alignItems: align,
+    justifyItems: justify,
+    ...rest,
+  })
+})
+RefGrid.displayName = 'RefGrid'

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -69,6 +69,6 @@ Icon.displayName = 'Icon'
  * })
  * ```
  */
-export function configureIconElementsMap(elementsMap: IconElementsMap) {
+export function configureIconElementsMap(elementsMap: IconElementsMap): void {
   iconElementsMap = elementsMap
 }

--- a/src/components/Provider/Provider.tsx
+++ b/src/components/Provider/Provider.tsx
@@ -142,7 +142,7 @@ export function useTheme(): Theme {
 let preCompileMode = false
 let preCompileComponentsValue: Components = {}
 
-export function __initializePreCompileMode(components: Components) {
+export function __initializePreCompileMode(components: Components): void {
   preCompileMode = true
   preCompileComponentsValue = components
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,15 @@ export { Media, useMedia } from './components/Media/Media'
 export { Active } from './components/Active/Active'
 export { Alert } from './components/Alert/Alert'
 export { Badge } from './components/Badge/Badge'
-export { Block, type BlockProps } from './components/Block/Block'
+export { Block, type BlockProps, RefBlock } from './components/Block/Block'
 export { Button, type ButtonProps } from './components/Button/Button'
 export { Card } from './components/Card/Card'
 export { Close } from './components/Close/Close'
 export { Drawer } from './components/Drawer/Drawer'
 export { Dropdown } from './components/Dropdown/Dropdown'
-export { Flex, type FlexProps } from './components/Flex/Flex'
+export { Flex, type FlexProps, RefFlex } from './components/Flex/Flex'
 export { FormGroup } from './components/FormGroup/FormGroup'
-export { Grid, type GridProps } from './components/Grid/Grid'
+export { Grid, type GridProps, RefGrid } from './components/Grid/Grid'
 export {
   Icon,
   configureIconElementsMap,

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -6,7 +6,7 @@
  */
 
 import clsx, { type ClassValue } from 'clsx'
-import React from 'react'
+import React, { useRef } from 'react'
 import {
   Active,
   Alert,
@@ -18,9 +18,12 @@ import {
   Flex,
   Icon,
   Link,
+  RefBlock,
   Text,
   useTheme,
 } from '..'
+import { RefFlex } from '../components/Flex/Flex'
+import { RefGrid } from '../components/Grid/Grid'
 
 // Verify that the theme value accessed with theme hook is typed
 function ThemedComponent() {
@@ -93,6 +96,20 @@ const specialButton = (
     Special
   </SpecialButton>
 )
+
+function TestRef() {
+  const blockRef = useRef<HTMLDivElement>(null)
+  const flexRef = useRef<HTMLDivElement>(null)
+  const gridRef = useRef<HTMLDivElement>(null)
+
+  return (
+    <>
+      <RefBlock ref={blockRef}>w/Ref</RefBlock>
+      <RefFlex ref={flexRef}>w/Ref</RefFlex>
+      <RefGrid ref={flexRef}>w/Ref</RefGrid>
+    </>
+  )
+}
 
 // Wrapping an HTML el: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase#wrappingmirroring
 // Polymorphic component: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase#polymorphic-components-eg-with-as-props


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

Provide ref-able versions of Block,Flex,Grid

### Notes

- Useful for creating layouts with ResizeObservers or hooks that measure dimensions.
