### PR TITLE
Fix: flexGrow and flexShrink default values

### DIFF
--- a/src/theme/theme-defaults.ts
+++ b/src/theme/theme-defaults.ts
@@ -93,8 +93,8 @@ export const themeDefaults = {
   },
 
   // --- FLEX/GRID
-  flexGrow: { 0: 0 },
-  flexShrink: { 0: 0 },
+  flexGrow: { DEFAULT: 1, 0: 0 },
+  flexShrink: { DEFAULT: 1, 0: 0 },
 
   // --- SPACING
   spacing: {


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Fixes `flexGrow` and `flexShrink` not working as boolean values._


