### PR TITLE
New: Support precompiling forwardRef components

### DIFF
--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -1,4 +1,4 @@
-import { type FC, forwardRef } from 'react'
+import { forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
@@ -16,30 +16,11 @@ export interface BlockProps extends ComponentBaseProps<'div'> {}
  * </Block>
  * ```
  */
-export const Block: FC<BlockProps> = (props) => {
-  return element({
-    ...useThemeProps('Block'),
-    ...props,
-  })
-}
-Block.displayName = 'Block'
-
-/**
- * **[📝 RefBlock docs](https://componentry.design/docs/components/block)**
- *
- * `RefBlock` provides a ref-able `Block` element.
- * @example
- * ```tsx
- * <RefBlock ref={ref} mt={2} mx={3}>
- *   ...
- * </RefBlock>
- * ```
- */
-export const RefBlock = forwardRef<HTMLDivElement, BlockProps>((props, ref) => {
+export const Block = forwardRef<HTMLDivElement, BlockProps>((props, ref) => {
   return element({
     ref,
     ...useThemeProps('Block'),
     ...props,
   })
 })
-RefBlock.displayName = 'RefBlock'
+Block.displayName = 'Block'

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unused-prop-types */
-import { type FC, forwardRef } from 'react'
+import { forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
@@ -29,35 +29,7 @@ export type FlexProps = FlexPropsBase & ComponentBaseProps<'div'>
  * </Flex>
  * ```
  */
-export const Flex: FC<FlexProps> = (props) => {
-  const { align, direction, justify, wrap, ...rest } = {
-    ...useThemeProps('Flex'),
-    ...props,
-  }
-
-  return element({
-    display: 'flex',
-    alignItems: align,
-    flexDirection: direction,
-    flexWrap: wrap,
-    justifyContent: justify,
-    ...rest,
-  })
-}
-Flex.displayName = 'Flex'
-
-/**
- * **[📝 RefFlex docs](https://componentry.design/docs/components/flex)**
- *
- * `RefFlex` provides a ref-able `Flex` element.
- * @example
- * ```tsx
- * <RefFlex ref={ref} align="center" gap={2}>
- *   ...
- * </RefFlex>
- * ```
- */
-export const RefFlex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
+export const Flex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
   const { align, direction, justify, wrap, ...rest } = {
     ...useThemeProps('Flex'),
     ...props,
@@ -73,4 +45,4 @@ export const RefFlex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
     ...rest,
   })
 })
-RefFlex.displayName = 'RefFlex'
+Flex.displayName = 'Flex'

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unused-prop-types */
-import { type FC, forwardRef } from 'react'
+import { forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
@@ -25,33 +25,7 @@ export type GridProps = GridPropsBase & ComponentBaseProps<'div'>
  * </Grid>
  * ```
  */
-export const Grid: FC<GridProps> = (props) => {
-  const { align, justify, ...rest } = {
-    ...useThemeProps('Grid'),
-    ...props,
-  }
-
-  return element({
-    display: 'grid',
-    alignItems: align,
-    justifyItems: justify,
-    ...rest,
-  })
-}
-Grid.displayName = 'Grid'
-
-/**
- * **[📝 Grid docs](https://componentry.design/docs/components/grid)**
- *
- * `Grid` provides a ref-able `Grid` element.
- * @example
- * ```tsx
- * <RefGrid ref={ref} gap={2}>
- *   ...
- * </RefGrid>
- * ```
- */
-export const RefGrid = forwardRef<HTMLDivElement, GridProps>((props, ref) => {
+export const Grid = forwardRef<HTMLDivElement, GridProps>((props, ref) => {
   const { align, justify, ...rest } = {
     ...useThemeProps('Grid'),
     ...props,
@@ -65,4 +39,4 @@ export const RefGrid = forwardRef<HTMLDivElement, GridProps>((props, ref) => {
     ...rest,
   })
 })
-RefGrid.displayName = 'RefGrid'
+Grid.displayName = 'Grid'

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -1,4 +1,4 @@
-import { type ComponentType, type FC } from 'react'
+import { type ComponentType, forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { type MergePropTypes } from '../../utils/types'
@@ -52,18 +52,19 @@ let textElementMap: TextElementsMap = {
  * </Text>
  * ```
  */
-export const Text: FC<TextProps> = (props) => {
+export const Text = forwardRef<HTMLElement, TextProps>((props, ref) => {
   const { variant = 'body', ...rest } = {
     ...useThemeProps('Text'),
     ...props,
   }
 
   return element({
+    ref,
     as: textElementMap[variant],
     componentCx: `C9Y-Text-base C9Y-Text-${variant}`,
     ...rest,
   })
-}
+})
 Text.displayName = 'Text'
 
 /**
@@ -81,6 +82,6 @@ Text.displayName = 'Text'
  * })
  * ```
  */
-export function configureTextElementsMap(elementsMap: TextElementsMap) {
+export function configureTextElementsMap(elementsMap: TextElementsMap): void {
   textElementMap = { ...textElementMap, ...elementsMap }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,15 @@ export { Media, useMedia } from './components/Media/Media'
 export { Active } from './components/Active/Active'
 export { Alert } from './components/Alert/Alert'
 export { Badge } from './components/Badge/Badge'
-export { Block, type BlockProps, RefBlock } from './components/Block/Block'
+export { Block, type BlockProps } from './components/Block/Block'
 export { Button, type ButtonProps } from './components/Button/Button'
 export { Card } from './components/Card/Card'
 export { Close } from './components/Close/Close'
 export { Drawer } from './components/Drawer/Drawer'
 export { Dropdown } from './components/Dropdown/Dropdown'
-export { Flex, type FlexProps, RefFlex } from './components/Flex/Flex'
+export { Flex, type FlexProps } from './components/Flex/Flex'
 export { FormGroup } from './components/FormGroup/FormGroup'
-export { Grid, type GridProps, RefGrid } from './components/Grid/Grid'
+export { Grid, type GridProps } from './components/Grid/Grid'
 export {
   Icon,
   configureIconElementsMap,

--- a/src/plugin-babel/__fixtures__/basics/code.js
+++ b/src/plugin-babel/__fixtures__/basics/code.js
@@ -1,0 +1,14 @@
+import { Block, Flex, Grid, Text } from 'componentry'
+
+export default function Test() {
+  // Test that:
+  // 1. Basic component transform works
+  return (
+    <Grid>
+      <Flex p={2}>
+        <Text variant='h3'>Precompiled for</Text>
+      </Flex>
+      <Block>SPEED</Block>
+    </Grid>
+  )
+}

--- a/src/plugin-babel/__fixtures__/basics/output.js
+++ b/src/plugin-babel/__fixtures__/basics/output.js
@@ -1,0 +1,23 @@
+import { Block, Flex, Grid, Text } from 'componentry'
+import { jsx as _jsx } from 'react/jsx-runtime'
+import { jsxs as _jsxs } from 'react/jsx-runtime'
+export default function Test() {
+  // Test that:
+  // 1. Basic component transform works
+  return /*#__PURE__*/ _jsxs('div', {
+    className: 'grid',
+    children: [
+      /*#__PURE__*/ _jsx('div', {
+        className: 'flex p-2',
+        children: /*#__PURE__*/ _jsx('h3', {
+          className: 'C9Y-Text-base C9Y-Text-h3',
+          children: 'Precompiled for',
+        }),
+      }),
+      /*#__PURE__*/ _jsx('div', {
+        className: '',
+        children: 'SPEED',
+      }),
+    ],
+  })
+}

--- a/src/plugin-babel/__fixtures__/refs/code.js
+++ b/src/plugin-babel/__fixtures__/refs/code.js
@@ -1,0 +1,14 @@
+import { useRef } from 'react'
+import { Flex, Text } from 'componentry'
+
+export default function Test() {
+  const ref = useRef(null)
+
+  // Test that:
+  // 1. Refs are passed through
+  return (
+    <Flex ref={ref} p={2}>
+      <Text variant='h3'>Precompiled for speed</Text>
+    </Flex>
+  )
+}

--- a/src/plugin-babel/__fixtures__/refs/output.js
+++ b/src/plugin-babel/__fixtures__/refs/output.js
@@ -1,0 +1,16 @@
+import { useRef } from 'react'
+import { Flex, Text } from 'componentry'
+import { jsx as _jsx } from 'react/jsx-runtime'
+export default function Test() {
+  const ref = useRef(null) // Test that:
+  // 1. Refs are passed through
+
+  return /*#__PURE__*/ _jsx('div', {
+    className: 'flex p-2',
+    ref: ref,
+    children: /*#__PURE__*/ _jsx('h3', {
+      className: 'C9Y-Text-base C9Y-Text-h3',
+      children: 'Precompiled for speed',
+    }),
+  })
+}

--- a/src/plugin-babel/plugin.spec.js
+++ b/src/plugin-babel/plugin.spec.js
@@ -18,6 +18,16 @@ pluginTester({
   // Array of tests format used to allow more descriptive test titles
   tests: [
     {
+      title: 'transforms components',
+      fixture: '__fixtures__/basics/code.js',
+      outputFixture: '__fixtures__/basics/output.js',
+    },
+    {
+      title: 'passes through refs',
+      fixture: '__fixtures__/refs/code.js',
+      outputFixture: '__fixtures__/refs/output.js',
+    },
+    {
       title: 'transforms as prop',
       fixture: '__fixtures__/as-prop/code.js',
       outputFixture: '__fixtures__/as-prop/output.js',

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -16,14 +16,12 @@ import {
   Card,
   Close,
   Flex,
+  Grid,
   Icon,
   Link,
-  RefBlock,
   Text,
   useTheme,
 } from '..'
-import { RefFlex } from '../components/Flex/Flex'
-import { RefGrid } from '../components/Grid/Grid'
 
 // Verify that the theme value accessed with theme hook is typed
 function ThemedComponent() {
@@ -104,9 +102,9 @@ function TestRef() {
 
   return (
     <>
-      <RefBlock ref={blockRef}>w/Ref</RefBlock>
-      <RefFlex ref={flexRef}>w/Ref</RefFlex>
-      <RefGrid ref={flexRef}>w/Ref</RefGrid>
+      <Block ref={blockRef}>w/Ref</Block>
+      <Flex ref={flexRef}>w/Ref</Flex>
+      <Grid ref={flexRef}>w/Ref</Grid>
     </>
   )
 }


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Upgrades the Babel plugin to work with ref-components._

### Notes

- Block, Flex, Grid, and Text now accept refs
- Performance overhead from refs is assumed to be at least partially offset by pre-compiling these elements.
