### PR TITLE
API Docs: Add Button and Link types

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -4,11 +4,18 @@
  * creating documentation.
  */
 
-export { type FlexPropsBase } from './components/Flex/Flex'
-export { type GridPropsBase } from './components/Grid/Grid'
-export { type IconPropsBase, type IconPropsOverrides } from './components/Icon/Icon'
+export {
+  type ButtonPropsDefaults,
+  type ButtonPropsOverrides,
+} from './components/Button/Button'
+export { type ButtonStyles } from './components/Button/Button.styles'
+export { type FlexPropsDefaults } from './components/Flex/Flex'
+export { type GridPropsDefaults } from './components/Grid/Grid'
+export { type IconPropsDefaults, type IconPropsOverrides } from './components/Icon/Icon'
 export { type IconStyles } from './components/Icon/Icon.styles'
-export { type TextPropsBase, type TextPropsOverrides } from './components/Text/Text'
+export { type LinkPropsDefaults, type LinkPropsOverrides } from './components/Link/Link'
+export { type LinkStyles } from './components/Link/Link.styles'
+export { type TextPropsDefaults, type TextPropsOverrides } from './components/Text/Text'
 export { type TextStyles } from './components/Text/Text.styles'
 
 export {

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -1,11 +1,12 @@
 import { getMergedConfig } from '../../plugin-postcss/configs'
+import { StylesDefinition } from '../../utils/types'
 
 const { theme } = getMergedConfig()
 
 //                                        <Button /> styles
 // --------------------------------------------------------
 
-export const buttonStyles = {
+export const buttonStyles: ButtonStyles = {
   // BASE
   '.C9Y-Button-base': {
     alignItems: 'center',
@@ -89,4 +90,25 @@ export const buttonStyles = {
     fontSize: theme.fontSize.lg,
     padding: '0 2rem',
   },
+}
+
+export interface ButtonStyles {
+  /** Base class applied to all variants for shared structural styles */
+  '.C9Y-Button-base': { '&.C9Y-disabled': StylesDefinition } & StylesDefinition
+  /** Variant class applied when `variant="filled"` */
+  '.C9Y-Button-filled': {
+    '&:hover, &.C9Y-hover': StylesDefinition
+    '&:active, &.C9Y-active': StylesDefinition
+    '&.C9Y-disabled': StylesDefinition
+  } & StylesDefinition
+  /** Variant class applied when `variant="outlined"` */
+  '.C9Y-Button-outlined': {
+    '&:hover, &.C9Y-hover': StylesDefinition
+    '&:active, &.C9Y-active': StylesDefinition
+    '&.C9Y-disabled': StylesDefinition
+  } & StylesDefinition
+  /** Sizing class applied when `size="small"` */
+  '.C9Y-Button-smallSize': StylesDefinition
+  /** Sizing class applied when `size="large"` */
+  '.C9Y-Button-largeSize': StylesDefinition
 }

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -4,7 +4,7 @@ import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
 
-export interface FlexPropsBase {
+export interface FlexPropsDefaults {
   /** Sets an `align-items` style */
   align?: 'start' | 'end' | 'center' | 'baseline' | 'stretch'
   /** Sets a `flex-direction` flex style */
@@ -15,7 +15,7 @@ export interface FlexPropsBase {
   wrap?: 'wrap' | 'nowrap' | 'wrap-reverse'
 }
 
-export type FlexProps = FlexPropsBase & ComponentBaseProps<'div'>
+export type FlexProps = FlexPropsDefaults & ComponentBaseProps<'div'>
 
 /**
  * **[📝 Flex docs](https://componentry.design/docs/components/flex)**

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -4,14 +4,14 @@ import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { useThemeProps } from '../Provider/Provider'
 
-export interface GridPropsBase {
+export interface GridPropsDefaults {
   /** Sets an `align-items` style */
   align?: 'start' | 'end' | 'center' | 'baseline' | 'stretch'
   /** Sets a `justify-items` style */
   justify?: 'start' | 'end' | 'center' | 'stretch'
 }
 
-export type GridProps = GridPropsBase & ComponentBaseProps<'div'>
+export type GridProps = GridPropsDefaults & ComponentBaseProps<'div'>
 
 /**
  * **[📝 Grid docs](https://componentry.design/docs/components/grid)**

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -7,7 +7,7 @@ import { useThemeProps } from '../Provider/Provider'
 /** Module augmentation interface for overriding component props' types */
 export interface IconPropsOverrides {}
 
-export interface IconPropsBase {
+export interface IconPropsDefaults {
   /** External path to symbol sprite  */
   externalURI?: string
   /** ID for the `iconElementsMap` or href attribute for symbol sprites */
@@ -16,11 +16,11 @@ export interface IconPropsBase {
   variant?: 'font'
 }
 
-export type IconProps = MergePropTypes<IconPropsBase, IconPropsOverrides> &
+export type IconProps = MergePropTypes<IconPropsDefaults, IconPropsOverrides> &
   ComponentBaseProps<'svg'>
 
 /** Mapping of icon IDs to components rendered by Icon */
-export type IconElementsMap = { [ID: string]: ComponentType<any> }
+export type IconElementsMap = { [ID: string]: ComponentType<unknown> }
 let iconElementsMap: IconElementsMap = {}
 
 /**

--- a/src/components/Link/Link.styles.ts
+++ b/src/components/Link/Link.styles.ts
@@ -1,11 +1,12 @@
 import { getMergedConfig } from '../../plugin-postcss/configs'
+import { StylesDefinition } from '../../utils/types'
 
 const { theme } = getMergedConfig()
 
 //                                         <Link /> styles
 // -------------------------------------------------------
 
-export const linkStyles = {
+export const linkStyles: LinkStyles = {
   // BASE
   '.C9Y-Link-base': {
     // Reset browser defaults for when Link renders a button element
@@ -31,6 +32,19 @@ export const linkStyles = {
       color: theme.colors.primary[700],
     },
   },
+}
+
+export interface LinkStyles {
+  /** Base class applied to all variants for shared structural styles */
+  '.C9Y-Link-base': StylesDefinition
+  /** Variant class applied when `variant="text"` */
+  '.C9Y-Link-text': {
+    '&:hover': StylesDefinition
+  } & StylesDefinition
+  /** Variant class applied when `variant="inherit"` */
+  '.C9Y-Link-inherit': {
+    '&:hover': StylesDefinition
+  } & StylesDefinition
 }
 
 // --- ℹ️ Disabled link styles

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -7,12 +7,12 @@ import { useThemeProps } from '../Provider/Provider'
 /** Module augmentation interface for overriding component props' types */
 export interface TextPropsOverrides {}
 
-export interface TextPropsBase {
+export interface TextPropsDefaults {
   /** Display variant */
   variant?: 'h1' | 'h2' | 'h3' | 'body' | 'code' | 'small'
 }
 
-export type TextProps = MergePropTypes<TextPropsBase, TextPropsOverrides> &
+export type TextProps = MergePropTypes<TextPropsDefaults, TextPropsOverrides> &
   ComponentBaseProps<'div'>
 
 /**
@@ -26,7 +26,7 @@ export type TextProps = MergePropTypes<TextPropsBase, TextPropsOverrides> &
  * ```
  */
 export type TextElementsMap = {
-  [Variant: string]: keyof JSX.IntrinsicElements | ComponentType<any>
+  [Variant: string]: keyof JSX.IntrinsicElements | ComponentType<unknown>
 }
 /**
  * Internal map used for final rendering


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Adds Button and Link types to the API docs types._

### Notes

- Renames original Block/Flex/Grid "base" props to match more frequent "defaults" props
