### PR TITLE
Docs: Upgrade TSDoc and type display

### DIFF
--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -5,10 +5,17 @@ import { useThemeProps } from '../Provider/Provider'
 
 export interface BlockProps extends ComponentBaseProps<'div'> {}
 
+// ✨ Nice display type for IntelliSense
+export interface Block {
+  (props: BlockProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  displayName?: string
+}
+
 /**
- * **[📝 Block docs](https://componentry.design/docs/components/block)**
+ * #### [📝 Block](https://componentry.design/docs/components/block)
  *
- * `Block` provides block level elements with access to theme utility props.
+ * Block provides block level layout elements with access to theme utility
+ * props.
  * @example
  * ```tsx
  * <Block mt={2} mx={3}>
@@ -16,7 +23,7 @@ export interface BlockProps extends ComponentBaseProps<'div'> {}
  * </Block>
  * ```
  */
-export const Block = forwardRef<HTMLDivElement, BlockProps>((props, ref) => {
+export const Block: Block = forwardRef((props, ref) => {
   return element({
     ref,
     ...useThemeProps('Block'),

--- a/src/components/Button/Button.ts
+++ b/src/components/Button/Button.ts
@@ -25,11 +25,24 @@ export interface ButtonPropsDefaults {
 export type ButtonProps = MergePropTypes<ButtonPropsDefaults, ButtonPropsOverrides> &
   ComponentBaseProps<'button'>
 
+// ✨ Nice display type for IntelliSense
+export interface Button {
+  (props: ButtonProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  displayName?: string
+}
+
 /**
- * [Button component 📝](https://componentry.design/components/button)
- * @experimental
+ * #### [📝 Button](https://componentry.design/docs/components/button)
+ *
+ * Button provides actionable elements for creating accessible user interactions.
+ * @example
+ * ```tsx
+ * <Button onClick={() => buildRadical()}>
+ *   Build something radical
+ * </Button>
+ * ```
  */
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+export const Button: Button = forwardRef((props, ref) => {
   const {
     variant = 'filled',
     color,

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,7 +1,7 @@
-/* eslint-disable react/no-unused-prop-types */
 import { forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
+
 import { useThemeProps } from '../Provider/Provider'
 
 export interface FlexPropsDefaults {
@@ -17,10 +17,16 @@ export interface FlexPropsDefaults {
 
 export type FlexProps = FlexPropsDefaults & ComponentBaseProps<'div'>
 
+// ✨ Nice display type for IntelliSense
+export interface Flex {
+  (props: FlexProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  displayName?: string
+}
+
 /**
- * **[📝 Flex docs](https://componentry.design/docs/components/flex)**
+ * #### [📝 Flex](https://componentry.design/docs/components/flex)
  *
- * `Flex` provides consistent flexbox layouts using a flex container with
+ * Flex provides consistent flexbox layouts using a flex container with
  * utility props.
  * @example
  * ```tsx
@@ -29,7 +35,7 @@ export type FlexProps = FlexPropsDefaults & ComponentBaseProps<'div'>
  * </Flex>
  * ```
  */
-export const Flex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
+export const Flex: Flex = forwardRef((props, ref) => {
   const { align, direction, justify, wrap, ...rest } = {
     ...useThemeProps('Flex'),
     ...props,

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unused-prop-types */
 import { forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
@@ -13,10 +12,16 @@ export interface GridPropsDefaults {
 
 export type GridProps = GridPropsDefaults & ComponentBaseProps<'div'>
 
+// ✨ Nice display type for IntelliSense
+export interface Grid {
+  (props: GridProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  displayName?: string
+}
+
 /**
- * **[📝 Grid docs](https://componentry.design/docs/components/grid)**
+ * #### [📝 Grid](https://componentry.design/docs/components/grid)
  *
- * `Grid` provides consistent CSS grid layouts using a grid container with
+ * Grid provides consistent CSS grid layouts using a grid container with
  * utility props.
  * @example
  * ```tsx
@@ -25,7 +30,7 @@ export type GridProps = GridPropsDefaults & ComponentBaseProps<'div'>
  * </Grid>
  * ```
  */
-export const Grid = forwardRef<HTMLDivElement, GridProps>((props, ref) => {
+export const Grid: Grid = forwardRef((props, ref) => {
   const { align, justify, ...rest } = {
     ...useThemeProps('Grid'),
     ...props,

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ComponentType } from 'react'
+import { type ComponentType, forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { type MergePropTypes } from '../../utils/types'

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,57 +1,16 @@
-import { type ComponentType, type FC } from 'react'
+import { forwardRef, type ComponentType } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { type MergePropTypes } from '../../utils/types'
 import { useThemeProps } from '../Provider/Provider'
 
-/** Module augmentation interface for overriding component props' types */
-export interface IconPropsOverrides {}
-
-export interface IconPropsDefaults {
-  /** External path to symbol sprite  */
-  externalURI?: string
-  /** ID for the `iconElementsMap` or href attribute for symbol sprites */
-  id: string
-  /** Display variant */
-  variant?: 'font'
-}
-
-export type IconProps = MergePropTypes<IconPropsDefaults, IconPropsOverrides> &
-  ComponentBaseProps<'svg'>
+// --------------------------------------------------------
+// ICON ELEMENTS MAP
 
 /** Mapping of icon IDs to components rendered by Icon */
 export type IconElementsMap = { [ID: string]: ComponentType<unknown> }
+
 let iconElementsMap: IconElementsMap = {}
-
-/**
- * **[📝 Icon docs](https://componentry.design/docs/components/icon)**
- *
- * `Icon` provides consistent iconography using SVG icons.
- * @example
- * ```tsx
- * <Icon id="coffee" />
- * ```
- */
-export const Icon: FC<IconProps> = (props) => {
-  const {
-    externalURI = '',
-    id,
-    variant = 'font',
-    ...rest
-  } = { ...useThemeProps('Icon'), ...props }
-
-  const hasMappedElement = id in iconElementsMap
-
-  return element({
-    as: hasMappedElement ? iconElementsMap[id] : 'svg',
-    children: hasMappedElement ? undefined : <use href={`${externalURI}#${id}`} />,
-    componentCx: `C9Y-Icon-base C9Y-Icon-${variant} icon-${id}`,
-    role: 'img',
-    'aria-label': id,
-    ...rest,
-  })
-}
-Icon.displayName = 'Icon'
 
 /**
  * Configuration method for defining the elements to render for each Icon ID.
@@ -72,3 +31,60 @@ Icon.displayName = 'Icon'
 export function configureIconElementsMap(elementsMap: IconElementsMap): void {
   iconElementsMap = elementsMap
 }
+
+// --------------------------------------------------------
+// ICON COMPONENT
+
+/** Module augmentation interface for overriding component props' types */
+export interface IconPropsOverrides {}
+
+export interface IconPropsDefaults {
+  /** External path to symbol sprite  */
+  externalURI?: string
+  /** ID for the `iconElementsMap` or href attribute for symbol sprites */
+  id: string
+  /** Display variant */
+  variant?: 'font'
+}
+
+export type IconProps = MergePropTypes<IconPropsDefaults, IconPropsOverrides> &
+  ComponentBaseProps<'svg'>
+
+// ✨ Nice display type for IntelliSense
+export interface Icon {
+  (
+    props: IconProps & { ref?: React.ForwardedRef<SVGSVGElement> },
+  ): React.ReactElement | null
+  displayName?: string
+}
+
+/**
+ * #### [📝 Icon](https://componentry.design/docs/components/icon)
+ *
+ * Icon provides consistent iconography using SVG icons.
+ * @example
+ * ```tsx
+ * <Icon id="coffee" />
+ * ```
+ */
+export const Icon: Icon = forwardRef((props, ref) => {
+  const {
+    externalURI = '',
+    id,
+    variant = 'font',
+    ...rest
+  } = { ...useThemeProps('Icon'), ...props }
+
+  const hasMappedElement = id in iconElementsMap
+
+  return element({
+    ref,
+    as: hasMappedElement ? iconElementsMap[id] : 'svg',
+    children: hasMappedElement ? undefined : <use href={`${externalURI}#${id}`} />,
+    componentCx: `C9Y-Icon-base C9Y-Icon-${variant} icon-${id}`,
+    role: 'img',
+    'aria-label': id,
+    ...rest,
+  })
+})
+Icon.displayName = 'Icon'

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -21,11 +21,24 @@ export interface LinkPropsDefaults {
 export type LinkProps = MergePropTypes<LinkPropsDefaults, LinkPropsOverrides> &
   ComponentBaseProps<'a'>
 
+// ✨ Nice display type for IntelliSense
+export interface Link {
+  (props: LinkProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  displayName?: string
+}
+
 /**
- * [Link component 📝](https://componentry.design/components/link)
- * @experimental
+ * #### [📝 Link component](https://componentry.design/docs/components/link)
+ *
+ * Link provides actionable elements in the style of hyperlinks.
+ * @example
+ * ```tsx
+ * <Link to="/">
+ *   Home
+ * <Link>
+ * ```
  */
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+export const Link: Link = forwardRef((props, ref) => {
   const { variant = 'text', ...merged } = {
     ...useThemeProps('Link'),
     ...props,

--- a/src/components/Provider/Provider.tsx
+++ b/src/components/Provider/Provider.tsx
@@ -99,7 +99,7 @@ const ComponentryCtx = createContext<null | { components: Components; theme: The
   null,
 )
 
-interface ProviderProps {
+interface ComponentryProviderProps {
   children: ReactElement
   /** Component default props */
   components?: Components
@@ -107,10 +107,29 @@ interface ProviderProps {
   theme?: Theme
 }
 
+export interface ComponentryProvider {
+  (props: ComponentryProviderProps): JSX.Element
+  displayName?: string
+}
+
 /**
- * [Componentry context provider 📝](https://componentry.design/components/provider)
+ * #### [📝 ComponentryProvider](https://componentry.design/components/provider)
+ *
+ * Provider for the application theme and default component props.
+ * @example
+ * const appTheme = {}
+ * const defaultProps = {}
+ * ```tsx
+ * <ComponentryProvider theme={appTheme} components={defaultProps}>
+ *  <App />
+ * </ComponentryProvider>
+ * ```
  */
-export function ComponentryProvider({ children, components, theme }: ProviderProps) {
+export const ComponentryProvider: ComponentryProvider = ({
+  children,
+  components,
+  theme,
+}) => {
   const contextValue = useMemo(() => {
     return { components: components ?? {}, theme: theme ?? themeDefaults }
   }, [components, theme])

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -4,16 +4,8 @@ import { element } from '../../utils/element-creator'
 import { type MergePropTypes } from '../../utils/types'
 import { useThemeProps } from '../Provider/Provider'
 
-/** Module augmentation interface for overriding component props' types */
-export interface TextPropsOverrides {}
-
-export interface TextPropsDefaults {
-  /** Display variant */
-  variant?: 'h1' | 'h2' | 'h3' | 'body' | 'code' | 'small'
-}
-
-export type TextProps = MergePropTypes<TextPropsDefaults, TextPropsOverrides> &
-  ComponentBaseProps<'div'>
+// --------------------------------------------------------
+// TEXT ELEMENTS MAP
 
 /**
  * Mapping of Text variants to rendered elements
@@ -42,32 +34,6 @@ let textElementMap: TextElementsMap = {
 }
 
 /**
- * **[📝 Text docs](https://componentry.design/docs/components/text)**
- *
- * `Text` provides consistently themed typography elements.
- * @example
- * ```tsx
- * <Text variant="h1">
- *   Componentry
- * </Text>
- * ```
- */
-export const Text = forwardRef<HTMLElement, TextProps>((props, ref) => {
-  const { variant = 'body', ...rest } = {
-    ...useThemeProps('Text'),
-    ...props,
-  }
-
-  return element({
-    ref,
-    as: textElementMap[variant],
-    componentCx: `C9Y-Text-base C9Y-Text-${variant}`,
-    ...rest,
-  })
-})
-Text.displayName = 'Text'
-
-/**
  * Configuration method for defining the elements to render for each text
  * variant.
  * @remarks
@@ -85,3 +51,49 @@ Text.displayName = 'Text'
 export function configureTextElementsMap(elementsMap: TextElementsMap): void {
   textElementMap = { ...textElementMap, ...elementsMap }
 }
+
+// --------------------------------------------------------
+// TEXT COMPONENT
+
+/** Module augmentation interface for overriding component props' types */
+export interface TextPropsOverrides {}
+
+export interface TextPropsDefaults {
+  /** Display variant */
+  variant?: 'h1' | 'h2' | 'h3' | 'body' | 'code' | 'small'
+}
+
+export type TextProps = MergePropTypes<TextPropsDefaults, TextPropsOverrides> &
+  ComponentBaseProps<'div'>
+
+// ✨ Nice display type for IntelliSense
+export interface Text {
+  (props: TextProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  displayName?: string
+}
+
+/**
+ * #### [📝 Text docs](https://componentry.design/docs/components/text)
+ *
+ * Text provides consistently themed typography elements.
+ * @example
+ * ```tsx
+ * <Text variant="h1">
+ *   Componentry
+ * </Text>
+ * ```
+ */
+export const Text: Text = forwardRef((props, ref) => {
+  const { variant = 'body', ...rest } = {
+    ...useThemeProps('Text'),
+    ...props,
+  }
+
+  return element({
+    ref,
+    as: textElementMap[variant],
+    componentCx: `C9Y-Text-base C9Y-Text-${variant}`,
+    ...rest,
+  })
+})
+Text.displayName = 'Text'

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -15,6 +15,7 @@ import {
   Button,
   Card,
   Close,
+  ComponentryProvider,
   Flex,
   Grid,
   Icon,
@@ -28,6 +29,12 @@ function ThemedComponent() {
   const theme = useTheme()
   return <div style={{ color: theme.colors.inverse }}>THEME</div>
 }
+
+const provider = (
+  <ComponentryProvider>
+    <div>the app</div>
+  </ComponentryProvider>
+)
 
 const testActive = (
   <Active defaultActive={false} onDeactivated={console.log}>
@@ -99,12 +106,14 @@ function TestRef() {
   const blockRef = useRef<HTMLDivElement>(null)
   const flexRef = useRef<HTMLDivElement>(null)
   const gridRef = useRef<HTMLDivElement>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
 
   return (
     <>
       <Block ref={blockRef}>w/Ref</Block>
       <Flex ref={flexRef}>w/Ref</Flex>
-      <Grid ref={flexRef}>w/Ref</Grid>
+      <Grid ref={gridRef}>w/Ref</Grid>
+      <Icon ref={svgRef} id='test' />
     </>
   )
 }


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Provides better IntelliSense for all components_

**Before**

This type isn't readable and distracts from any other docs

<img width="894" alt="Screen Shot 2022-04-24 at 1 50 18 PM" src="https://user-images.githubusercontent.com/8461733/165091563-f85201af-5d5c-47c6-b114-cb1fbf1e93be.png">

**After**

Streamlined type lets other docs info shine

<img width="535" alt="image" src="https://user-images.githubusercontent.com/8461733/165091821-5909c3a3-f89b-48e1-ac07-e2e2aff0b189.png">


