### PR TITLE
Button icons

### DIFF
--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -16,8 +16,10 @@
 /* Normally this would be an override in theme, but we don't have a theme for this
  Storybook for simplicity -> Feather icons use stroke, not fill. */
 .C9Y-Icon-font {
+  /* Storybook uses Feather icons -> which use a 2px stroke instead of a fill */
   fill: none;
   stroke: currentColor;
+  stroke-width: 2px;
 }
 
 .sbdocs-h2 {

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -65,16 +65,56 @@ Pass `fullWidth` to make a button fill its parent container:
 
 ## Disabled
 
-Pass `disabled` to make a button disabled. Disabled buttons have `pointer-events: none`
-set which will prevent user actions.
+- Controlled by `disabled` prop
+- Adds `disabled` attribute to element and `.C9Y-Disabled` class
+- Adds `pointer-events: none` to prevent user actions
+- Prop `wrapWhenDisabled` controls wrapping disabled buttons with a span to support
+  accessing a ref (eg for tooltip) and to support setting `cursor: not-allowed` which has
+  no effect on `pointer-events: none` button element
 
-<div className='flex flex-row items-center gap-4'>
-  <Button variant='filled' disabled>
-    Button
-  </Button>
-  <Button variant='outlined' disabled>
-    Button
-  </Button>
+<div className='flex flex-col items-center'>
+  <div className='flex flex-row items-center gap-4'>
+    <Button variant='filled' disabled>
+      Button
+    </Button>
+    <Button variant='outlined' disabled>
+      Button
+    </Button>
+  </div>
+</div>
+
+## Icons
+
+- Button supports `startIcon` and `endIcon` props
+- Icon sizes are defined with a single level selector (important for ability to easily
+  override by consumer)
+- Button spacing is defaulted with `gap`
+
+<div className='flex flex-col items-center gap-4'>
+  <div className='flex gap-4'>
+    <Button variant='filled' startIcon='code' size='small'>
+      Button
+    </Button>
+    <Button variant='filled' endIcon='code' size='small'>
+      Button
+    </Button>
+  </div>
+  <div className='flex gap-4'>
+    <Button variant='filled' startIcon='code'>
+      Button
+    </Button>
+    <Button variant='filled' endIcon='code'>
+      Button
+    </Button>
+  </div>
+  <div className='flex gap-4'>
+    <Button variant='filled' startIcon='code' size='large'>
+      Button
+    </Button>
+    <Button variant='filled' endIcon='code' size='large'>
+      Button
+    </Button>
+  </div>
 </div>
 
 ## Buttons with hrefs
@@ -82,16 +122,5 @@ set which will prevent user actions.
 Buttons with an `href` will be rendered as anchors:
 
 <Button href='#test'>Button</Button>
-
-## Input buttons
-
-Pass an `as` prop to render input elements styled as buttons:
-
-<div className='flex flex-row items-center gap-4'>
-  <Button>Button</Button>
-  <Button as='input' value='Input' />
-  <Button as='input' type='submit' value='Submit' />
-  <Button as='input' type='reset' value='Reset' />
-</div>
 
 <ArgsTable of={Button} />

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -72,7 +72,7 @@ Pass `fullWidth` to make a button fill its parent container:
   accessing a ref (eg for tooltip) and to support setting `cursor: not-allowed` which has
   no effect on `pointer-events: none` button element
 
-<div className='flex flex-col items-center'>
+<div className='flex flex-col items-center gap-4'>
   <div className='flex flex-row items-center gap-4'>
     <Button variant='filled' disabled>
       Button
@@ -81,6 +81,9 @@ Pass `fullWidth` to make a button fill its parent container:
       Button
     </Button>
   </div>
+  <Button disabled fullWidth>
+    Button
+  </Button>
 </div>
 
 ## Icons
@@ -121,6 +124,11 @@ Pass `fullWidth` to make a button fill its parent container:
 
 Buttons with an `href` will be rendered as anchors:
 
-<Button href='#test'>Button</Button>
+<div className='flex flex-col items-center gap-4'>
+  <Button href='#test'>Button</Button>
+  <Button disabled href='#test'>
+    Button
+  </Button>
+</div>
 
 <ArgsTable of={Button} />

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -12,15 +12,21 @@ export const buttonStyles: ButtonStyles = {
     alignItems: 'center',
     display: 'inline-flex',
     justifyContent: 'center',
+    gap: '0.5rem',
+    fontSize: '0.875rem',
     lineHeight: 1, // ensures text is center aligned within flex layout
 
+    border: 'none', // reset borders for easier opt-in styling
     userSelect: 'none', // Prevent text selection on click of buttons
     whiteSpace: 'nowrap', // By default button content shouldn't wrap
 
     '&.C9Y-disabled': {
-      cursor: 'default',
       pointerEvents: 'none',
     },
+  },
+
+  '.C9Y-Button-DisabledWrapper': {
+    cursor: 'not-allowed',
   },
 
   // VARIANTS
@@ -28,23 +34,18 @@ export const buttonStyles: ButtonStyles = {
     height: '2rem',
     padding: '0 1rem',
     backgroundColor: theme.colors.primary[500],
-    border: `1px solid ${theme.colors.primary[500]}`,
     borderRadius: theme.borderRadius.DEFAULT,
     color: theme.colors.inverse,
-    fontSize: theme.fontSize.sm,
 
     transition: 'background-color 0.15s linear',
 
     '&:hover, &.C9Y-hover': {
-      borderColor: theme.colors.primary[500],
       backgroundColor: theme.colors.primary[700],
     },
     '&:active, &.C9Y-active': {
-      borderColor: theme.colors.primary[700],
       backgroundColor: theme.colors.primary[900],
     },
     '&.C9Y-disabled': {
-      borderColor: theme.colors.primary[300],
       backgroundColor: theme.colors.primary[300],
     },
 
@@ -59,9 +60,8 @@ export const buttonStyles: ButtonStyles = {
     border: `1px solid ${theme.colors.primary[500]}`,
     borderRadius: theme.borderRadius.DEFAULT,
     color: theme.colors.primary[500],
-    fontSize: theme.fontSize.sm,
 
-    transition: 'color 0.15s linear',
+    transition: 'color, border-color 0.15s linear',
 
     '&:hover, &.C9Y-hover': {
       borderColor: theme.colors.primary[700],
@@ -81,20 +81,35 @@ export const buttonStyles: ButtonStyles = {
   '.C9Y-Button-smallSize': {
     height: '1.5rem',
     borderRadius: theme.borderRadius.DEFAULT,
-    fontSize: theme.fontSize.sm,
+    fontSize: '0.75rem',
     padding: '0rem 0.5rem',
   },
   '.C9Y-Button-largeSize': {
     height: '2.5rem',
     borderRadius: theme.borderRadius.md,
-    fontSize: theme.fontSize.lg,
+    fontSize: '1rem',
     padding: '0 2rem',
+  },
+
+  // ICONS
+  '.C9Y-Button-Icon': {
+    fontSize: '1rem',
+  },
+  '.C9Y-Button-Icon-smallSize': {
+    fontSize: '0.75rem',
+  },
+  '.C9Y-Button-Icon-largeSize': {
+    fontSize: '1.25rem',
   },
 }
 
 export interface ButtonStyles {
   /** Base class applied to all variants for shared structural styles */
   '.C9Y-Button-base': { '&.C9Y-disabled': StylesDefinition } & StylesDefinition
+  /** Class applied to disabled button wrapper element */
+  '.C9Y-Button-DisabledWrapper': StylesDefinition
+  /** Base class applied to all Button Icons */
+  '.C9Y-Button-Icon': StylesDefinition
   /** Variant class applied when `variant="filled"` */
   '.C9Y-Button-filled': {
     '&:hover, &.C9Y-hover': StylesDefinition
@@ -111,4 +126,8 @@ export interface ButtonStyles {
   '.C9Y-Button-smallSize': StylesDefinition
   /** Sizing class applied when `size="large"` */
   '.C9Y-Button-largeSize': StylesDefinition
+  /** Sizing class applied to Button Icons when `size="small"` */
+  '.C9Y-Button-Icon-smallSize': StylesDefinition
+  /** Sizing class applied Button Icons when `size="large"` */
+  '.C9Y-Button-Icon-largeSize': StylesDefinition
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { ForwardedRef, JSXElementConstructor, ReactElement, forwardRef } from 'react'
+import { type ForwardedRef, type ReactElement, type ReactNode, forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { type MergePropTypes } from '../../utils/types'
@@ -10,15 +10,13 @@ import { useThemeProps } from '../Provider/Provider'
 export interface ButtonPropsOverrides {}
 
 export interface ButtonPropsDefaults {
-  children: ReactElement
+  children: ReactNode
   /** Button variant color */
   color?: 'primary'
   /** Disables the element, preventing mouse and keyboard events */
   disabled?: boolean
   /** Icon positioned after button content */
-  endIcon?:
-    | string
-    | JSXElementConstructor<{ className?: string; [Prop: string]: unknown }>
+  endIcon?: string | JSX.Element
   /** Toggles full width element layout */
   fullWidth?: boolean
   /** HTML element href */
@@ -26,9 +24,7 @@ export interface ButtonPropsDefaults {
   /** Sets the display size */
   size?: 'small' | 'large'
   /** Icon positioned before button content */
-  startIcon?:
-    | string
-    | JSXElementConstructor<{ className?: string; [Prop: string]: unknown }>
+  startIcon?: string | JSX.Element
   /** Indicates whether buttons in a disabled state should be wrapped with a span */
   wrapWhenDisabled?: boolean
   /** Display variant */
@@ -60,8 +56,8 @@ export const Button: Button = forwardRef((props, ref) => {
     variant = 'filled',
     children,
     disabled,
-    startIcon: StartIcon,
-    endIcon: EndIcon,
+    startIcon,
+    endIcon,
     color,
     fullWidth,
     size,
@@ -74,17 +70,17 @@ export const Button: Button = forwardRef((props, ref) => {
 
   const iconCx = clsx('C9Y-Button-Icon', { [`C9Y-Button-Icon-${size}Size`]: size })
   const decoratedStartIcon =
-    StartIcon === undefined ? null : typeof StartIcon === 'string' ? (
-      <Icon id={StartIcon} className={iconCx} />
+    startIcon === undefined ? null : typeof startIcon === 'string' ? (
+      <Icon id={startIcon} className={iconCx} />
     ) : (
-      <StartIcon className={iconCx} />
+      <span className={iconCx}>{startIcon}</span>
     )
 
   const decoratedEndIcon =
-    EndIcon === undefined ? null : typeof EndIcon === 'string' ? (
-      <Icon id={EndIcon} className={iconCx} />
+    endIcon === undefined ? null : typeof endIcon === 'string' ? (
+      <Icon id={endIcon} className={iconCx} />
     ) : (
-      <EndIcon className={iconCx} />
+      <span className={iconCx}>{endIcon}</span>
     )
 
   const contents = element({
@@ -112,7 +108,9 @@ export const Button: Button = forwardRef((props, ref) => {
   })
 
   return disabled && wrapWhenDisabled ? (
-    <span className='C9Y-Button-DisabledWrapper'>{contents}</span>
+    <span className={clsx('C9Y-Button-DisabledWrapper', { 'w-full': fullWidth })}>
+      {contents}
+    </span>
   ) : (
     contents
   )

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,23 +1,36 @@
-import { forwardRef } from 'react'
+import clsx from 'clsx'
+import { ForwardedRef, JSXElementConstructor, ReactElement, forwardRef } from 'react'
 import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { type MergePropTypes } from '../../utils/types'
+import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
 
 // Module augmentation interface for overriding component props' types
 export interface ButtonPropsOverrides {}
 
 export interface ButtonPropsDefaults {
+  children: ReactElement
   /** Button variant color */
   color?: 'primary'
   /** Disables the element, preventing mouse and keyboard events */
   disabled?: boolean
+  /** Icon positioned after button content */
+  endIcon?:
+    | string
+    | JSXElementConstructor<{ className?: string; [Prop: string]: unknown }>
   /** Toggles full width element layout */
   fullWidth?: boolean
   /** HTML element href */
   href?: string
   /** Sets the display size */
   size?: 'small' | 'large'
+  /** Icon positioned before button content */
+  startIcon?:
+    | string
+    | JSXElementConstructor<{ className?: string; [Prop: string]: unknown }>
+  /** Indicates whether buttons in a disabled state should be wrapped with a span */
+  wrapWhenDisabled?: boolean
   /** Display variant */
   variant?: 'filled' | 'outlined'
 }
@@ -27,7 +40,7 @@ export type ButtonProps = MergePropTypes<ButtonPropsDefaults, ButtonPropsOverrid
 
 // ✨ Nice display type for IntelliSense
 export interface Button {
-  (props: ButtonProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  (props: ButtonProps & { ref?: ForwardedRef<unknown> }): ReactElement | null
   displayName?: string
 }
 
@@ -45,17 +58,38 @@ export interface Button {
 export const Button: Button = forwardRef((props, ref) => {
   const {
     variant = 'filled',
+    children,
+    disabled,
+    startIcon: StartIcon,
+    endIcon: EndIcon,
     color,
     fullWidth,
     size,
+    wrapWhenDisabled = true,
     ...merged
   } = {
     ...useThemeProps('Button'),
     ...props,
   }
 
-  return element({
+  const iconCx = clsx('C9Y-Button-Icon', { [`C9Y-Button-Icon-${size}Size`]: size })
+  const decoratedStartIcon =
+    StartIcon === undefined ? null : typeof StartIcon === 'string' ? (
+      <Icon id={StartIcon} className={iconCx} />
+    ) : (
+      <StartIcon className={iconCx} />
+    )
+
+  const decoratedEndIcon =
+    EndIcon === undefined ? null : typeof EndIcon === 'string' ? (
+      <Icon id={EndIcon} className={iconCx} />
+    ) : (
+      <EndIcon className={iconCx} />
+    )
+
+  const contents = element({
     ref,
+    disabled,
     // If an href is passed, this instance should render an anchor tag
     as: merged.href ? 'a' : 'button',
     type: merged.href ? undefined : 'button',
@@ -67,7 +101,20 @@ export const Button: Button = forwardRef((props, ref) => {
         'w-full': fullWidth,
       },
     ],
+    children: (
+      <>
+        {decoratedStartIcon}
+        {children}
+        {decoratedEndIcon}
+      </>
+    ),
     ...merged,
   })
+
+  return disabled && wrapWhenDisabled ? (
+    <span className='C9Y-Button-DisabledWrapper'>{contents}</span>
+  ) : (
+    contents
+  )
 })
 Button.displayName = 'Button'

--- a/src/plugin-postcss/configs.ts
+++ b/src/plugin-postcss/configs.ts
@@ -1,20 +1,26 @@
 import { lilconfigSync } from 'lilconfig'
 
-import { createTheme } from '../theme/theme'
+import { type Theme, createTheme } from '../theme/theme'
 
 const explorer = lilconfigSync('componentry')
 
 // --------------------------------------------------------
 // Config
 
+type Config = {
+  theme: Theme
+  components: any
+  foundation: any
+}
+
 const configSearchResults = explorer.search()
 
 const userConfig = configSearchResults?.config ?? {}
 
-const mergedConfig = {
+const mergedConfig: Config = {
   theme: userConfig.theme ?? createTheme(),
   components: userConfig.components ?? {},
   foundation: userConfig.foundation ?? {},
 }
 
-export const getMergedConfig = () => mergedConfig
+export const getMergedConfig = (): Config => mergedConfig

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -53,9 +53,14 @@ const testBadge = <Badge variant='filled'>77</Badge>
 
 const testBlock = <Block>test block</Block>
 const testButton = (
-  <Button variant='filled' size='small' active>
-    Click
-  </Button>
+  <>
+    <Button variant='filled' size='small' startIcon='code' active>
+      Click
+    </Button>
+    <Button variant='filled' size='small' startIcon={<Icon id='code' />} active>
+      Click
+    </Button>
+  </>
 )
 const testCard = (
   <Card p={2} className='rad'>


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Adds support for icons to Button and improves API for disabled buttons_

Closes #376 

### Notes

- Add `startIcon` and `endIcon` props
- Add `wrapWhenDisabled` prop

<!-- Thank you for contributing, you are AWESOME 🥳 -->
