### PR TITLE
Update: Better focus styles

### DIFF
--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -27,4 +27,5 @@
   margin-top: 20px !important;
 }
 
+@componentry utilities;
 @tailwind utilities;

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -19,10 +19,6 @@ export const buttonStyles: ButtonStyles = {
     border: 'none', // reset borders for easier opt-in styling
     userSelect: 'none', // Prevent text selection on click of buttons
     whiteSpace: 'nowrap', // By default button content shouldn't wrap
-
-    '&.C9Y-disabled': {
-      pointerEvents: 'none',
-    },
   },
 
   '.C9Y-Button-DisabledWrapper': {
@@ -105,7 +101,7 @@ export const buttonStyles: ButtonStyles = {
 
 export interface ButtonStyles {
   /** Base class applied to all variants for shared structural styles */
-  '.C9Y-Button-base': { '&.C9Y-disabled': StylesDefinition } & StylesDefinition
+  '.C9Y-Button-base': StylesDefinition
   /** Class applied to disabled button wrapper element */
   '.C9Y-Button-DisabledWrapper': StylesDefinition
   /** Base class applied to all Button Icons */

--- a/src/styles/foundation.styles.ts
+++ b/src/styles/foundation.styles.ts
@@ -51,6 +51,13 @@ export const foundationStyles = {
     boxSizing: 'border-box',
   },
 
+  // Modern browser focus styles for keyboard users: Will add a focus outline for elements
+  // like buttons when keyboard activated only
+  ':focus-visible': {
+    outline: `${theme.colors.primary[500]} solid 2px`,
+    outlineOffset: '2px',
+  },
+
   html: {
     lineHeight: theme.lineHeight.normal, // Use a consistent sensible line-height in all browsers.
     tabSize: 4, // Use a more readable tab size.
@@ -152,10 +159,6 @@ export const foundationStyles = {
 
   "[role='button']": {
     cursor: 'pointer', // Set the default cursor for buttons.
-  },
-
-  ':disabled': {
-    cursor: 'default', // Make sure disabled buttons don't get the pointer cursor.
   },
 
   'input, optgroup, select, textarea': {

--- a/src/styles/states.styles.ts
+++ b/src/styles/states.styles.ts
@@ -1,0 +1,29 @@
+/**
+ * Classes that _MAY_ be applied to components to represent their current state.
+ *
+ * NOTE - Componentry does not yet consistently apply these classes for all states,
+ * but they are provided here to document what classes _should_ be used to represent
+ * these states.
+ *
+ * Ref:
+ * - https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
+ * - https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+ */
+export const states = {
+  /** Class applied when element is being clicked  */
+  '.C9Y-active': {},
+  /** Class applied when element is being hovered */
+  '.C9Y-hover': {},
+  /** Class applied when element has been clicked */
+  '.C9Y-focus': {},
+  /** Class applied when an element whose contents fail to validate */
+  '.C9Y-invalid': {},
+  /** Class applied when an element can't be activated or receive focus */
+  '.C9Y-disabled': {
+    pointerEvents: 'none',
+  },
+  /** Class applied when element has been checked or toggled to an on state */
+  '.C9Y-checked': {},
+  /** Class applied when element has been selected */
+  '.C9Y-selected': {},
+}


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Improve library styles system for component states._

Closes #279 

### Notes

- Adds Componentry `@utilities` import
- Sets all library disabled elements to `pointer-events: none`
- Adds a themed `:focus-visible` style to Foundations

- If needed provide context with additional notes...

<!-- Thank you for contributing, you are AWESOME 🥳 -->
