### PR TITLE
Update: Handle disabled patterns in Link

### DIFF
--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -41,7 +41,7 @@ export const buttonStyles: ButtonStyles = {
     '&:active, &.C9Y-active': {
       backgroundColor: theme.colors.primary[900],
     },
-    '&.C9Y-disabled': {
+    '&:disabled, &.C9Y-disabled': {
       backgroundColor: theme.colors.primary[300],
     },
 
@@ -67,7 +67,7 @@ export const buttonStyles: ButtonStyles = {
       borderColor: theme.colors.primary[900],
       color: theme.colors.primary[900],
     },
-    '&.C9Y-disabled': {
+    '&:disabled, &.C9Y-disabled': {
       borderColor: theme.colors.primary[300],
       color: theme.colors.primary[300],
     },
@@ -102,7 +102,7 @@ export const buttonStyles: ButtonStyles = {
 export interface ButtonStyles {
   /** Base class applied to all variants for shared structural styles */
   '.C9Y-Button-base': StylesDefinition
-  /** Class applied to disabled button wrapper element */
+  /** Class applied to disabled buttons' wrapper element */
   '.C9Y-Button-DisabledWrapper': StylesDefinition
   /** Base class applied to all Button Icons */
   '.C9Y-Button-Icon': StylesDefinition
@@ -110,13 +110,13 @@ export interface ButtonStyles {
   '.C9Y-Button-filled': {
     '&:hover, &.C9Y-hover': StylesDefinition
     '&:active, &.C9Y-active': StylesDefinition
-    '&.C9Y-disabled': StylesDefinition
+    '&:disabled, &.C9Y-disabled': StylesDefinition
   } & StylesDefinition
   /** Variant class applied when `variant="outlined"` */
   '.C9Y-Button-outlined': {
     '&:hover, &.C9Y-hover': StylesDefinition
     '&:active, &.C9Y-active': StylesDefinition
-    '&.C9Y-disabled': StylesDefinition
+    '&:disabled, &.C9Y-disabled': StylesDefinition
   } & StylesDefinition
   /** Sizing class applied when `size="small"` */
   '.C9Y-Button-smallSize': StylesDefinition

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -25,10 +25,10 @@ export interface ButtonPropsDefaults {
   size?: 'small' | 'large'
   /** Icon positioned before button content */
   startIcon?: string | JSX.Element
-  /** Indicates whether buttons in a disabled state should be wrapped with a span */
-  wrapWhenDisabled?: boolean
   /** Display variant */
   variant?: 'filled' | 'outlined'
+  /** Indicates whether buttons in a disabled state should be wrapped with a span */
+  wrapWhenDisabled?: boolean
 }
 
 export type ButtonProps = MergePropTypes<ButtonPropsDefaults, ButtonPropsOverrides> &

--- a/src/components/Link/Link.stories.mdx
+++ b/src/components/Link/Link.stories.mdx
@@ -7,12 +7,11 @@ import { Link } from './Link'
 
 # Link
 
-The Link component provides traditional link elements. Link elements without an `href` are
-rendered with button elements.
+The Link component provides traditional link elements.
 
 ## Variants
 
-A `text` variant link:
+Link has a single variant, `text`, that can be used inside any text element:
 
 <Story
   name='Link'
@@ -26,23 +25,35 @@ A `text` variant link:
 >
   <Link href='#test'>Text link</Link>
   <Text variant='h2'>
-    The inherit variant can be used for a{' '}
-    <Link variant='inherit' href='#test'>
-      Link
+    Link can be used inside{' '}
+    <Link fontSize='inherit' href='#test'>
+      headings
     </Link>{' '}
-    inside of some text.
+    .
   </Text>
 </Story>
 
 ## Button links
 
-Links without an href are rendered as buttons.
+Link elements without an `href` are rendered with button elements.
 
 <Link onClick={console.log}>Button link</Link>
 
+## Disabled
+
+<div className='flex flex-col items-center gap-4'>
+  <Link disabled href='#test'>
+    Text link
+  </Link>
+  <Link disabled onClick={console.log}>
+    Button link
+  </Link>
+</div>
+
 ## Routing
 
-A default `as` prop can be configured to handle routing components like React Router.
+The `as` prop can be configured to handle routing components like React Router, using the
+theme to set as default.
 
 ## Props
 

--- a/src/components/Link/Link.styles.ts
+++ b/src/components/Link/Link.styles.ts
@@ -13,23 +13,23 @@ export const linkStyles: LinkStyles = {
     border: 'none',
   },
 
-  // VARIANTS
-  '.C9Y-Link-text': {
-    fontSize: theme.fontSize.body,
-    color: theme.colors.primary[500],
-    textDecoration: 'underline',
-    '&:hover': {
-      color: theme.colors.primary[700],
-    },
+  '.C9Y-Link-DisabledWrapper': {
+    cursor: 'not-allowed',
   },
 
-  '.C9Y-Link-inherit': {
+  // VARIANTS
+  '.C9Y-Link-text': {
     fontSize: 'inherit',
-    fontWeight: 'inherit',
     color: theme.colors.primary[500],
     textDecoration: 'underline',
-    '&:hover': {
+    '&:hover, .C9Y-hover': {
       color: theme.colors.primary[700],
+    },
+    '&:active, &.C9Y-active': {
+      color: theme.colors.primary[900],
+    },
+    '&:disabled, &.C9Y-disabled': {
+      color: theme.colors.primary[300],
     },
   },
 }
@@ -37,18 +37,12 @@ export const linkStyles: LinkStyles = {
 export interface LinkStyles {
   /** Base class applied to all variants for shared structural styles */
   '.C9Y-Link-base': StylesDefinition
+  /** Class applied to disabled links' wrapper element */
+  '.C9Y-Link-DisabledWrapper': StylesDefinition
   /** Variant class applied when `variant="text"` */
   '.C9Y-Link-text': {
-    '&:hover': StylesDefinition
-  } & StylesDefinition
-  /** Variant class applied when `variant="inherit"` */
-  '.C9Y-Link-inherit': {
-    '&:hover': StylesDefinition
+    '&:hover, .C9Y-hover': StylesDefinition
+    '&:active, &.C9Y-active': StylesDefinition
+    '&:disabled, &.C9Y-disabled': StylesDefinition
   } & StylesDefinition
 }
-
-// --- ℹ️ Disabled link styles
-// Componentry doesn't include disabled link styles as a UX best
-// practice, but if necessary it's best to define normal link styles
-// using `.link[href]` as the selector, and `link` as a 'disabled' link and
-// then don't pass an href to create a 'placeholder link'

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -15,7 +15,9 @@ export interface LinkPropsDefaults {
   /** Routing to */
   to?: string
   /** Display variant */
-  variant?: 'text' | 'inherit'
+  variant?: 'text'
+  /** Indicates whether buttons in a disabled state should be wrapped with a span */
+  wrapWhenDisabled?: boolean
 }
 
 export type LinkProps = MergePropTypes<LinkPropsDefaults, LinkPropsOverrides> &
@@ -39,17 +41,28 @@ export interface Link {
  * ```
  */
 export const Link: Link = forwardRef((props, ref) => {
-  const { variant = 'text', ...merged } = {
+  const {
+    disabled,
+    variant = 'text',
+    wrapWhenDisabled = true,
+    ...merged
+  } = {
     ...useThemeProps('Link'),
     ...props,
   }
 
-  return element({
+  const contents = element({
     ref,
     as: merged.href ? 'a' : 'button',
     type: merged.href ? undefined : 'button',
     componentCx: `C9Y-Link-base C9Y-Link-${variant}`,
     ...merged,
   })
+
+  return disabled && wrapWhenDisabled ? (
+    <span className='C9Y-Link-DisabledWrapper'>{contents}</span>
+  ) : (
+    contents
+  )
 })
 Link.displayName = 'Link'

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -43,18 +43,21 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     >
       Item 3
     </button>
-    <button
-      aria-controls="test-guid-four-content"
-      aria-selected="false"
-      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction C9Y-disabled C9Y-disabled"
-      data-active-id="four"
-      disabled=""
-      id="test-guid-four-tab"
-      role="tab"
-      type="button"
+    <span
+      class="C9Y-Link-DisabledWrapper"
     >
-      Disabled
-    </button>
+      <button
+        aria-controls="test-guid-four-content"
+        aria-selected="false"
+        class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction C9Y-disabled"
+        data-active-id="four"
+        id="test-guid-four-tab"
+        role="tab"
+        type="button"
+      >
+        Disabled
+      </button>
+    </span>
   </div>
   <div
     class="C9Y-TabsContentContainer"

--- a/src/theme/theme-defaults.ts
+++ b/src/theme/theme-defaults.ts
@@ -28,6 +28,7 @@ export const themeDefaults = {
     current: 'currentColor',
     transparent: 'transparent',
     background: '#fff',
+    inherit: 'inherit',
     inverse: '#eff',
     gray,
     primary: {
@@ -163,6 +164,7 @@ export const themeDefaults = {
     mono: "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
   },
   fontSize: {
+    inherit: 'inherit',
     base: '1rem', // HTML base size
     sm: '0.875rem',
     lg: '1.25rem',


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Update Link to match Button disabled patterns_

### Notes

- Add `wrapWhenDisabled` to Link
- Add text color and font-size `inherit` to theme
- Update Link variant to `text` only, using `inherit` as default.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
