### PR TITLE
Fix: Incorrect type when using 'to' with Button/Link

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -69,26 +69,13 @@ export const Button: Button = forwardRef((props, ref) => {
   }
 
   const iconCx = clsx('C9Y-Button-Icon', { [`C9Y-Button-Icon-${size}Size`]: size })
-  const decoratedStartIcon =
-    startIcon === undefined ? null : typeof startIcon === 'string' ? (
-      <Icon id={startIcon} className={iconCx} />
-    ) : (
-      <span className={iconCx}>{startIcon}</span>
-    )
-
-  const decoratedEndIcon =
-    endIcon === undefined ? null : typeof endIcon === 'string' ? (
-      <Icon id={endIcon} className={iconCx} />
-    ) : (
-      <span className={iconCx}>{endIcon}</span>
-    )
-
   const contents = element({
     ref,
     disabled,
     // If an href is passed, this instance should render an anchor tag
     as: merged.href ? 'a' : 'button',
-    type: merged.href ? undefined : 'button',
+    // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
+    type: merged.href || merged.to ? undefined : 'button',
     componentCx: [
       `C9Y-Button-base C9Y-Button-${variant}`,
       {
@@ -99,9 +86,17 @@ export const Button: Button = forwardRef((props, ref) => {
     ],
     children: (
       <>
-        {decoratedStartIcon}
+        {startIcon && (
+          <span className={iconCx}>
+            {typeof startIcon === 'string' ? <Icon id={startIcon} /> : startIcon}
+          </span>
+        )}
         {children}
-        {decoratedEndIcon}
+        {endIcon && (
+          <span className={iconCx}>
+            {typeof endIcon === 'string' ? <Icon id={endIcon} /> : endIcon}
+          </span>
+        )}
       </>
     ),
     ...merged,

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -12,8 +12,6 @@ export interface LinkPropsDefaults {
   disabled?: boolean
   /** HTML element href */
   href?: string
-  /** Routing to */
-  to?: string
   /** Display variant */
   variant?: 'text'
   /** Indicates whether buttons in a disabled state should be wrapped with a span */
@@ -54,7 +52,8 @@ export const Link: Link = forwardRef((props, ref) => {
   const contents = element({
     ref,
     as: merged.href ? 'a' : 'button',
-    type: merged.href ? undefined : 'button',
+    // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
+    type: merged.href || merged.to ? undefined : 'button',
     componentCx: `C9Y-Link-base C9Y-Link-${variant}`,
     ...merged,
   })


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Fixes a bug where using a ActionRoot component to support a `to` would result in anchor tags with `type="button"`_

### Notes

- Supporting by checking for `to` in each component instead of using a shared base component, this is the only logic and it's easier to duplicate.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
