### PR TITLE
Upgrade type definitions for components

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -20,6 +20,11 @@ export {
 export { type IconButtonStyles } from './components/IconButton/IconButton.styles'
 export { type LinkPropsDefaults, type LinkPropsOverrides } from './components/Link/Link'
 export { type LinkStyles } from './components/Link/Link.styles'
+export {
+  type PaperPropsDefaults,
+  type PaperPropsOverrides,
+} from './components/Paper/Paper'
+export { type PaperStyles } from './components/Paper/Paper.styles'
 export { type TextPropsDefaults, type TextPropsOverrides } from './components/Text/Text'
 export { type TextStyles } from './components/Text/Text.styles'
 

--- a/src/benchmarks/v1-utility-classes.ts
+++ b/src/benchmarks/v1-utility-classes.ts
@@ -8,7 +8,7 @@
  */
 
 import clsx from 'clsx'
-import { MergePropTypes } from '../utils/types'
+import { MergeTypes } from '../utils/types'
 
 /** Module augmentation interface for overriding default utility props' types */
 export interface UtilityPropsOverrides {}
@@ -141,7 +141,7 @@ export interface UtilityPropsBase {
 }
 
 /** Componentry utility props for including utility styles. */
-export type UtilityProps = MergePropTypes<UtilityPropsBase, UtilityPropsOverrides>
+export type UtilityProps = MergeTypes<UtilityPropsBase, UtilityPropsOverrides>
 
 // Map of utility props for quickly filtering out Componentry props from user props
 export const utilityProps: { [Prop in keyof UtilityPropsBase]: 1 } = {

--- a/src/components/Active/Active.ts
+++ b/src/components/Active/Active.ts
@@ -1,3 +1,4 @@
+import { ComponentPropsWithoutRef } from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
@@ -5,21 +6,24 @@ import {
   type ActiveActionBaseProps,
   type ActiveContainerBaseProps,
   type ActiveContentBaseProps,
-  type ComponentBaseProps,
 } from '../../utils/base-types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Link } from '../Link/Link'
 
 export interface ActiveProps
   extends ActiveContainerBaseProps,
-    ComponentBaseProps<'div'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface ActiveActionProps
   extends ActiveActionBaseProps,
-    ComponentBaseProps<'button'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'button'> {}
 
 export interface ActiveContentProps
   extends ActiveContentBaseProps,
-    ComponentBaseProps<'div'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface Active {
   (props: ActiveProps): React.ReactElement

--- a/src/components/Active/Active.ts
+++ b/src/components/Active/Active.ts
@@ -1,11 +1,11 @@
-import { ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  type ActiveActionBaseProps,
-  type ActiveContainerBaseProps,
-  type ActiveContentBaseProps,
+  ActiveActionBaseProps,
+  ActiveContainerBaseProps,
+  ActiveContentBaseProps,
 } from '../../utils/base-types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { Link } from '../Link/Link'
@@ -13,17 +13,17 @@ import { Link } from '../Link/Link'
 export interface ActiveProps
   extends ActiveContainerBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface ActiveActionProps
   extends ActiveActionBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'button'> {}
+    React.ComponentPropsWithoutRef<'button'> {}
 
 export interface ActiveContentProps
   extends ActiveContentBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface Active {
   (props: ActiveProps): React.ReactElement

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,16 +1,16 @@
-import React from 'react'
+import React, { ComponentPropsWithoutRef } from 'react'
 import { useActive, useVisible } from '../../hooks'
-import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
-import { type MergePropTypes } from '../../utils/types'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { closeBase } from '../Close/Close'
 import { useThemeProps } from '../Provider/Provider'
 
 /** Module augmentation interface for overriding component props' types */
 export interface AlertPropsOverrides {}
 
-interface AlertPropsBase {
+export interface AlertPropsBase {
   /** Sets a custom aria title */
   ariaTitle?: string
   /** Sets the theme color of the alert */
@@ -31,10 +31,13 @@ interface AlertPropsBase {
   variant?: 'filled'
 }
 
-export type AlertProps = MergePropTypes<AlertPropsBase, AlertPropsOverrides> &
-  ComponentBaseProps<'div'>
+export type AlertProps = Resolve<MergeTypes<AlertPropsBase, AlertPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithoutRef<'div'>
 
-interface AlertCloseProps extends ComponentBaseProps<'button'> {}
+export interface AlertCloseProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'button'> {}
 
 export interface Alert {
   (props: AlertProps): React.ReactElement | null

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { useActive, useVisible } from '../../hooks'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
@@ -33,11 +33,11 @@ export interface AlertPropsBase {
 
 export type AlertProps = Resolve<MergeTypes<AlertPropsBase, AlertPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithoutRef<'div'>
+  React.ComponentPropsWithoutRef<'div'>
 
 export interface AlertCloseProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'button'> {}
+    React.ComponentPropsWithoutRef<'button'> {}
 
 export interface Alert {
   (props: AlertProps): React.ReactElement | null

--- a/src/components/Badge/Badge.ts
+++ b/src/components/Badge/Badge.ts
@@ -1,19 +1,34 @@
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithoutRef } from 'react'
 import { element } from '../../utils/element-creator'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
-export interface BadgeProps extends ComponentBaseProps<'div'> {
+// Module augmentation interface for overriding component props' types
+export interface BadgePropsOverrides {}
+
+export interface BadgePropsDefaults {
   /** Variant color */
   color?: 'primary'
   /** Display variant */
   variant?: 'filled'
 }
 
+export type BadgeProps = Resolve<MergeTypes<BadgePropsDefaults, BadgePropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithoutRef<'div'>
+
+// ✨ Nice display type for IntelliSense
+export interface Badge {
+  (props: BadgeProps): React.ReactElement | null
+  displayName?: string
+}
+
 /**
  * [Badge component 📝](https://componentry.design/components/badge)
  * @experimental
  */
-export const Badge: React.FC<BadgeProps> = (props) => {
+export const Badge: Badge = (props) => {
   const {
     color,
     variant = 'filled',

--- a/src/components/Badge/Badge.ts
+++ b/src/components/Badge/Badge.ts
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -16,7 +16,7 @@ export interface BadgePropsDefaults {
 
 export type BadgeProps = Resolve<MergeTypes<BadgePropsDefaults, BadgePropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithoutRef<'div'>
+  React.ComponentPropsWithoutRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Badge {

--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -1,13 +1,21 @@
-import { forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
-export interface BlockProps extends ComponentBaseProps<'div'> {}
+// Module augmentation interface for overriding component props' types
+export interface BlockPropsOverrides {}
+
+export interface BlockPropsDefaults {}
+
+export type BlockProps = Resolve<MergeTypes<BlockPropsDefaults, BlockPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Block {
-  (props: BlockProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  (props: BlockProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -11,7 +11,7 @@ export interface BlockPropsDefaults {}
 
 export type BlockProps = Resolve<MergeTypes<BlockPropsDefaults, BlockPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'div'>
+  React.ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Block {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,5 @@
 import clsx from 'clsx'
-import {
-  type ComponentPropsWithRef,
-  type ReactElement,
-  type ReactNode,
-  forwardRef,
-} from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -15,7 +10,7 @@ import { useThemeProps } from '../Provider/Provider'
 export interface ButtonPropsOverrides {}
 
 export interface ButtonPropsDefaults {
-  children: ReactNode
+  children: React.ReactNode
   /** Button variant color */
   color?: 'primary'
   /** Disables the element, preventing mouse and keyboard events */
@@ -38,11 +33,11 @@ export interface ButtonPropsDefaults {
 
 export type ButtonProps = Resolve<MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'button'>
+  React.ComponentPropsWithRef<'button'>
 
 // ✨ Nice display type for IntelliSense
 export interface Button {
-  (props: ButtonProps): ReactElement | null
+  (props: ButtonProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,13 @@
 import clsx from 'clsx'
-import { type ForwardedRef, type ReactElement, type ReactNode, forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import {
+  type ComponentPropsWithRef,
+  type ReactElement,
+  type ReactNode,
+  forwardRef,
+} from 'react'
 import { element } from '../../utils/element-creator'
-import { type MergePropTypes } from '../../utils/types'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -31,12 +36,13 @@ export interface ButtonPropsDefaults {
   wrapWhenDisabled?: boolean
 }
 
-export type ButtonProps = MergePropTypes<ButtonPropsDefaults, ButtonPropsOverrides> &
-  ComponentBaseProps<'button'>
+export type ButtonProps = Resolve<MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'button'>
 
 // ✨ Nice display type for IntelliSense
 export interface Button {
-  (props: ButtonProps & { ref?: ForwardedRef<unknown> }): ReactElement | null
+  (props: ButtonProps): ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Card/Card.ts
+++ b/src/components/Card/Card.ts
@@ -1,17 +1,25 @@
-import React from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import React, { type ComponentPropsWithoutRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
-export interface CardProps extends ComponentBaseProps<'div'> {
+// Module augmentation interface for overriding component props' types
+export interface CardPropsOverrides {}
+
+export interface CardPropsDefaults {
   variant?: 'outlined'
 }
-interface CardBodyProps extends ComponentBaseProps<'div'> {}
-interface CardFooterProps extends ComponentBaseProps<'div'> {}
-interface CardHeaderProps extends ComponentBaseProps<'div'> {}
-interface CardTitleProps extends ComponentBaseProps<'h4'> {}
-interface CardSubtitleProps extends ComponentBaseProps<'h5'> {}
+
+export type CardProps = Resolve<MergeTypes<CardPropsDefaults, CardPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithoutRef<'div'>
+interface CardBodyProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+interface CardFooterProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+interface CardHeaderProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+interface CardTitleProps extends UtilityProps, ComponentPropsWithoutRef<'h4'> {}
+interface CardSubtitleProps extends UtilityProps, ComponentPropsWithoutRef<'h5'> {}
 
 export interface Card {
   (props: CardProps): React.ReactElement

--- a/src/components/Card/Card.ts
+++ b/src/components/Card/Card.ts
@@ -1,4 +1,4 @@
-import React, { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
 import { MergeTypes, Resolve } from '../../utils/types'
@@ -14,12 +14,12 @@ export interface CardPropsDefaults {
 
 export type CardProps = Resolve<MergeTypes<CardPropsDefaults, CardPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithoutRef<'div'>
-interface CardBodyProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-interface CardFooterProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-interface CardHeaderProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-interface CardTitleProps extends UtilityProps, ComponentPropsWithoutRef<'h4'> {}
-interface CardSubtitleProps extends UtilityProps, ComponentPropsWithoutRef<'h5'> {}
+  React.ComponentPropsWithoutRef<'div'>
+interface CardBodyProps extends UtilityProps, React.ComponentPropsWithoutRef<'div'> {}
+interface CardFooterProps extends UtilityProps, React.ComponentPropsWithoutRef<'div'> {}
+interface CardHeaderProps extends UtilityProps, React.ComponentPropsWithoutRef<'div'> {}
+interface CardTitleProps extends UtilityProps, React.ComponentPropsWithoutRef<'h4'> {}
+interface CardSubtitleProps extends UtilityProps, React.ComponentPropsWithoutRef<'h5'> {}
 
 export interface Card {
   (props: CardProps): React.ReactElement

--- a/src/components/Close/Close.tsx
+++ b/src/components/Close/Close.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { staticComponent } from '../../utils/static-component-builder'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -11,7 +11,7 @@ export interface ClosePropsDefaults {}
 
 export type CloseProps = Resolve<MergeTypes<ClosePropsDefaults, ClosePropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithoutRef<'button'>
+  React.ComponentPropsWithoutRef<'button'>
 
 export const closeBase: CloseProps & { componentCx: string } = {
   as: 'button',

--- a/src/components/Close/Close.tsx
+++ b/src/components/Close/Close.tsx
@@ -1,14 +1,19 @@
-import { type ClassValue } from 'clsx'
-import React from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithoutRef } from 'react'
 import { staticComponent } from '../../utils/static-component-builder'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Icon } from '../Icon/Icon'
 
-export interface CloseProps extends ComponentBaseProps<'button'> {
-  componentCx?: ClassValue
-}
+// Module augmentation interface for overriding component props' types
+export interface ClosePropsOverrides {}
 
-export const closeBase: CloseProps = {
+export interface ClosePropsDefaults {}
+
+export type CloseProps = Resolve<MergeTypes<ClosePropsDefaults, ClosePropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithoutRef<'button'>
+
+export const closeBase: CloseProps & { componentCx: string } = {
   as: 'button',
   type: 'button',
   componentCx: `C9Y-Close-base`,

--- a/src/components/Drawer/Drawer.ts
+++ b/src/components/Drawer/Drawer.ts
@@ -1,3 +1,4 @@
+import { type ComponentPropsWithoutRef } from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
@@ -5,24 +6,27 @@ import {
   type ActiveActionBaseProps,
   type ActiveContainerBaseProps,
   type ActiveContentBaseProps,
-  type ComponentBaseProps,
 } from '../../utils/base-types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Link } from '../Link/Link'
 
 export interface DrawerProps
   extends ActiveContainerBaseProps,
-    ComponentBaseProps<'div'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface DrawerActionProps
   extends ActiveActionBaseProps,
-    ComponentBaseProps<'button'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
 
 export interface DrawerContentProps
   extends ActiveContentBaseProps,
-    ComponentBaseProps<'div'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }

--- a/src/components/Drawer/Drawer.ts
+++ b/src/components/Drawer/Drawer.ts
@@ -1,11 +1,11 @@
-import { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  type ActiveActionBaseProps,
-  type ActiveContainerBaseProps,
-  type ActiveContentBaseProps,
+  ActiveActionBaseProps,
+  ActiveContainerBaseProps,
+  ActiveContentBaseProps,
 } from '../../utils/base-types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { Link } from '../Link/Link'
@@ -13,12 +13,12 @@ import { Link } from '../Link/Link'
 export interface DrawerProps
   extends ActiveContainerBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface DrawerActionProps
   extends ActiveActionBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'button'> {
+    React.ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
@@ -26,7 +26,7 @@ export interface DrawerActionProps
 export interface DrawerContentProps
   extends ActiveContentBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }

--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -1,11 +1,11 @@
-import { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  type ActiveActionBaseProps,
-  type ActiveContainerBaseProps,
-  type ActiveContentBaseProps,
+  ActiveActionBaseProps,
+  ActiveContainerBaseProps,
+  ActiveContentBaseProps,
 } from '../../utils/base-types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { Button } from '../Button/Button'
@@ -13,12 +13,12 @@ import { Button } from '../Button/Button'
 export interface DropdownProps
   extends ActiveContainerBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface DropdownActionProps
   extends ActiveActionBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'button'> {
+    React.ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
@@ -26,7 +26,7 @@ export interface DropdownActionProps
 export interface DropdownContentProps
   extends ActiveContentBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }
@@ -34,7 +34,7 @@ export interface DropdownContentProps
 export interface DropdownItemProps
   extends ActiveActionBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'button'> {
+    React.ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'unstyled'
 }

--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -1,3 +1,4 @@
+import { type ComponentPropsWithoutRef } from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
@@ -5,31 +6,35 @@ import {
   type ActiveActionBaseProps,
   type ActiveContainerBaseProps,
   type ActiveContentBaseProps,
-  type ComponentBaseProps,
 } from '../../utils/base-types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Button } from '../Button/Button'
 
 export interface DropdownProps
   extends ActiveContainerBaseProps,
-    ComponentBaseProps<'div'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface DropdownActionProps
   extends ActiveActionBaseProps,
-    ComponentBaseProps<'button'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
 
 export interface DropdownContentProps
   extends ActiveContentBaseProps,
-    ComponentBaseProps<'div'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }
 
 export interface DropdownItemProps
   extends ActiveActionBaseProps,
-    ComponentBaseProps<'button'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'unstyled'
 }

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,8 +1,12 @@
-import { forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 
 import { useThemeProps } from '../Provider/Provider'
+
+// Module augmentation interface for overriding component props' types
+export interface FlexPropsOverrides {}
 
 export interface FlexPropsDefaults {
   /** Sets an `align-items` style */
@@ -15,11 +19,13 @@ export interface FlexPropsDefaults {
   wrap?: 'wrap' | 'nowrap' | 'wrap-reverse'
 }
 
-export type FlexProps = FlexPropsDefaults & ComponentBaseProps<'div'>
+export type FlexProps = Resolve<MergeTypes<FlexPropsDefaults, FlexPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Flex {
-  (props: FlexProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  (props: FlexProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -21,7 +21,7 @@ export interface FlexPropsDefaults {
 
 export type FlexProps = Resolve<MergeTypes<FlexPropsDefaults, FlexPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'div'>
+  React.ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Flex {

--- a/src/components/FormGroup/FormGroup.ts
+++ b/src/components/FormGroup/FormGroup.ts
@@ -1,7 +1,8 @@
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithoutRef } from 'react'
 import { staticComponent } from '../../utils/static-component-builder'
+import { UtilityProps } from '../../utils/utility-classes'
 
-export interface FormGroupProps extends ComponentBaseProps<'div'> {}
+export interface FormGroupProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
 
 /**
  * [FormGroup component 📝](https://componentry.design/components/form-group)

--- a/src/components/FormGroup/FormGroup.ts
+++ b/src/components/FormGroup/FormGroup.ts
@@ -1,8 +1,10 @@
-import { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { staticComponent } from '../../utils/static-component-builder'
 import { UtilityProps } from '../../utils/utility-classes'
 
-export interface FormGroupProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface FormGroupProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
 
 /**
  * [FormGroup component 📝](https://componentry.design/components/form-group)

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -16,7 +16,7 @@ export interface GridPropsDefaults {
 
 export type GridProps = Resolve<MergeTypes<GridPropsDefaults, GridPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'div'>
+  React.ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Grid {

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,7 +1,11 @@
-import { forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
+
+// Module augmentation interface for overriding component props' types
+export interface GridPropsOverrides {}
 
 export interface GridPropsDefaults {
   /** Sets an `align-items` style */
@@ -10,11 +14,13 @@ export interface GridPropsDefaults {
   justify?: 'start' | 'end' | 'center' | 'stretch'
 }
 
-export type GridProps = GridPropsDefaults & ComponentBaseProps<'div'>
+export type GridProps = Resolve<MergeTypes<GridPropsDefaults, GridPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Grid {
-  (props: GridProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  (props: GridProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, type ComponentType, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -8,7 +8,7 @@ import { useThemeProps } from '../Provider/Provider'
 // ICON ELEMENTS MAP
 
 /** Mapping of icon IDs to components rendered by Icon */
-export type IconElementsMap = { [ID: string]: ComponentType<unknown> }
+export type IconElementsMap = { [ID: string]: React.ComponentType<unknown> }
 
 let iconElementsMap: IconElementsMap = {}
 
@@ -49,7 +49,7 @@ export interface IconPropsDefaults {
 
 export type IconProps = Resolve<MergeTypes<IconPropsDefaults, IconPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'svg'>
+  React.ComponentPropsWithRef<'svg'>
 
 // ✨ Nice display type for IntelliSense
 export interface Icon {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,7 +1,7 @@
-import { type ComponentType, forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, type ComponentType, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { type MergePropTypes } from '../../utils/types'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
 // --------------------------------------------------------
@@ -47,14 +47,13 @@ export interface IconPropsDefaults {
   variant?: 'font'
 }
 
-export type IconProps = MergePropTypes<IconPropsDefaults, IconPropsOverrides> &
-  ComponentBaseProps<'svg'>
+export type IconProps = Resolve<MergeTypes<IconPropsDefaults, IconPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'svg'>
 
 // ✨ Nice display type for IntelliSense
 export interface Icon {
-  (
-    props: IconProps & { ref?: React.ForwardedRef<SVGSVGElement> },
-  ): React.ReactElement | null
+  (props: IconProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,7 +1,7 @@
-import { type ForwardedRef, type ReactElement, forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, type ReactElement, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { type MergePropTypes } from '../../utils/types'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -27,15 +27,15 @@ export interface IconButtonPropsDefaults {
   variant?: 'transparent' | 'outlined'
 }
 
-export type IconButtonProps = MergePropTypes<
-  IconButtonPropsDefaults,
-  IconButtonPropsOverrides
+export type IconButtonProps = Resolve<
+  MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides>
 > &
-  ComponentBaseProps<'button'>
+  UtilityProps &
+  ComponentPropsWithRef<'button'>
 
 // ✨ Nice display type for IntelliSense
 export interface IconButton {
-  (props: IconButtonProps & { ref?: ForwardedRef<unknown> }): ReactElement | null
+  (props: IconButtonProps): ReactElement | null
   displayName?: string
 }
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, type ReactElement, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -31,11 +31,11 @@ export type IconButtonProps = Resolve<
   MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides>
 > &
   UtilityProps &
-  ComponentPropsWithRef<'button'>
+  React.ComponentPropsWithRef<'button'>
 
 // ✨ Nice display type for IntelliSense
 export interface IconButton {
-  (props: IconButtonProps): ReactElement | null
+  (props: IconButtonProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,21 +1,34 @@
 import { nanoid } from 'nanoid'
-import React, { createContext, useContext, useRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import React, {
+  type ComponentPropsWithoutRef,
+  createContext,
+  useContext,
+  useRef,
+} from 'react'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
-export interface InputProps extends ComponentBaseProps<'input'> {}
+export interface InputProps
+  extends UtilityProps,
+    Omit<ComponentPropsWithoutRef<'input'>, 'height' | 'width'> {}
 
-export interface InputDescriptionProps extends ComponentBaseProps<'div'> {}
+export interface InputDescriptionProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
-export interface InputErrorProps extends ComponentBaseProps<'div'> {}
+export interface InputErrorProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
 
-export interface InputFieldProps extends ComponentBaseProps<'input'> {
+export interface InputFieldProps
+  extends UtilityProps,
+    Omit<ComponentPropsWithoutRef<'input'>, 'height' | 'width'> {
   invalid?: boolean
 }
 
-export interface InputLabelProps extends ComponentBaseProps<'label'> {}
+export interface InputLabelProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'label'> {}
 
 export interface Input {
   (props: InputProps): React.ReactElement

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,10 +1,5 @@
 import { nanoid } from 'nanoid'
-import React, {
-  type ComponentPropsWithoutRef,
-  createContext,
-  useContext,
-  useRef,
-} from 'react'
+import React, { createContext, useContext, useRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -12,23 +7,25 @@ import { useThemeProps } from '../Provider/Provider'
 
 export interface InputProps
   extends UtilityProps,
-    Omit<ComponentPropsWithoutRef<'input'>, 'height' | 'width'> {}
+    Omit<React.ComponentPropsWithoutRef<'input'>, 'height' | 'width'> {}
 
 export interface InputDescriptionProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
-export interface InputErrorProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface InputErrorProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface InputFieldProps
   extends UtilityProps,
-    Omit<ComponentPropsWithoutRef<'input'>, 'height' | 'width'> {
+    Omit<React.ComponentPropsWithoutRef<'input'>, 'height' | 'width'> {
   invalid?: boolean
 }
 
 export interface InputLabelProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'label'> {}
+    React.ComponentPropsWithoutRef<'label'> {}
 
 export interface Input {
   (props: InputProps): React.ReactElement

--- a/src/components/Link/Link.stories.mdx
+++ b/src/components/Link/Link.stories.mdx
@@ -25,11 +25,7 @@ Link has a single variant, `text`, that can be used inside any text element:
 >
   <Link href='#test'>Text link</Link>
   <Text variant='h2'>
-    Link can be used inside{' '}
-    <Link fontSize='inherit' href='#test'>
-      headings
-    </Link>
-    .
+    Link can be used inside <Link href='#test'>headings</Link>.
   </Text>
 </Story>
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,7 +1,7 @@
-import { forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { type MergePropTypes } from '../../utils/types'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
 // Module augmentation interface for overriding component props' types
@@ -18,12 +18,13 @@ export interface LinkPropsDefaults {
   wrapWhenDisabled?: boolean
 }
 
-export type LinkProps = MergePropTypes<LinkPropsDefaults, LinkPropsOverrides> &
-  ComponentBaseProps<'a'>
+export type LinkProps = Resolve<MergeTypes<LinkPropsDefaults, LinkPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'a'>
 
 // ✨ Nice display type for IntelliSense
 export interface Link {
-  (props: LinkProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  (props: LinkProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -20,7 +20,7 @@ export interface LinkPropsDefaults {
 
 export type LinkProps = Resolve<MergeTypes<LinkPropsDefaults, LinkPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'a'>
+  React.ComponentPropsWithRef<'a'>
 
 // ✨ Nice display type for IntelliSense
 export interface Link {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,11 +1,16 @@
 import clsx from 'clsx'
 import { nanoid } from 'nanoid'
-import React, { createContext, useContext, useRef } from 'react'
+import React, {
+  type ComponentPropsWithoutRef,
+  createContext,
+  useContext,
+  useRef,
+} from 'react'
 
 import { useActive, useActiveScrollReset, useNoScroll, useVisible } from '../../hooks'
-import { type ComponentBaseProps } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
+import { UtilityProps } from '../../utils/utility-classes'
 import { closeBase } from '../Close/Close'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -17,7 +22,7 @@ type ModalCtx = {
 
 const ModalCtx = createContext<null | ModalCtx>(null)
 
-export interface ModalProps extends ComponentBaseProps<'div'> {
+export interface ModalProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {
   /** Sets modal screen alignment to centered */
   align?: 'center'
   /**
@@ -41,17 +46,19 @@ export interface ModalProps extends ComponentBaseProps<'div'> {
   transitionDuration?: number
 }
 
-export interface ModalBodyProps extends ComponentBaseProps<'div'> {}
+export interface ModalBodyProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
 
-export interface ModalCloseProps extends ComponentBaseProps<'button'> {}
+export interface ModalCloseProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'button'> {}
 
-export interface ModalFooterProps extends ComponentBaseProps<'div'> {}
+export interface ModalFooterProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
 
-export interface ModalHeaderProps extends ComponentBaseProps<'div'> {
+export interface ModalHeaderProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {
   close?: (evt: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-export interface ModalTitleProps extends ComponentBaseProps<'h2'> {
+export interface ModalTitleProps extends UtilityProps, ComponentPropsWithoutRef<'h2'> {
   id?: string
 }
 
@@ -163,7 +170,7 @@ Modal.displayName = 'Modal'
 // --------------------------------------------------------
 // Close
 
-Modal.Close = staticComponent('ModalClose', closeBase)
+Modal.Close = staticComponent<ModalCloseProps>('ModalClose', closeBase)
 
 // --------------------------------------------------------
 // Header

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,11 +1,6 @@
 import clsx from 'clsx'
 import { nanoid } from 'nanoid'
-import React, {
-  type ComponentPropsWithoutRef,
-  createContext,
-  useContext,
-  useRef,
-} from 'react'
+import React, { createContext, useContext, useRef } from 'react'
 
 import { useActive, useActiveScrollReset, useNoScroll, useVisible } from '../../hooks'
 import { element } from '../../utils/element-creator'
@@ -22,7 +17,7 @@ type ModalCtx = {
 
 const ModalCtx = createContext<null | ModalCtx>(null)
 
-export interface ModalProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {
+export interface ModalProps extends UtilityProps, React.ComponentPropsWithoutRef<'div'> {
   /** Sets modal screen alignment to centered */
   align?: 'center'
   /**
@@ -46,19 +41,27 @@ export interface ModalProps extends UtilityProps, ComponentPropsWithoutRef<'div'
   transitionDuration?: number
 }
 
-export interface ModalBodyProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface ModalBodyProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface ModalCloseProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'button'> {}
+    React.ComponentPropsWithoutRef<'button'> {}
 
-export interface ModalFooterProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface ModalFooterProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
 
-export interface ModalHeaderProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {
+export interface ModalHeaderProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {
   close?: (evt: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-export interface ModalTitleProps extends UtilityProps, ComponentPropsWithoutRef<'h2'> {
+export interface ModalTitleProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'h2'> {
   id?: string
 }
 

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, forwardRef } from 'react'
+import { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -13,7 +13,7 @@ export interface PaperPropsDefaults {
 
 export type PaperProps = Resolve<MergeTypes<PaperPropsDefaults, PaperPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'div'>
+  React.ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Paper {

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -1,7 +1,7 @@
-import { forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { type MergePropTypes } from '../../utils/types'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
 // Module augmentation interface for overriding component props' types
@@ -11,12 +11,13 @@ export interface PaperPropsDefaults {
   variant?: 'flat'
 }
 
-export type PaperProps = MergePropTypes<PaperPropsDefaults, PaperPropsOverrides> &
-  ComponentBaseProps<'div'>
+export type PaperProps = Resolve<MergeTypes<PaperPropsDefaults, PaperPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Paper {
-  (props: PaperProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  (props: PaperProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-
+import React, { type ComponentPropsWithoutRef } from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
@@ -7,32 +6,39 @@ import {
   type ActiveActionBaseProps,
   type ActiveContainerBaseProps,
   type ActiveContentBaseProps,
-  type ComponentBaseProps,
 } from '../../utils/base-types'
 import { staticComponent } from '../../utils/static-component-builder'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Button } from '../Button/Button'
 
 export interface PopoverProps
   extends ActiveContainerBaseProps,
-    ComponentBaseProps<'div'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface PopoverActionProps
   extends ActiveActionBaseProps,
-    ComponentBaseProps<'button'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
 
 export interface PopoverBodyProps
   extends ActiveContentBaseProps,
-    ComponentBaseProps<'div'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
-export interface PopoverContentProps extends ComponentBaseProps<'div'> {
+export interface PopoverContentProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }
 
-export interface PopoverHeadingProps extends ComponentBaseProps<'div'> {}
+export interface PopoverHeadingProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface Popover {
   (props: PopoverProps): React.ReactElement

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,11 +1,11 @@
-import React, { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  type ActiveActionBaseProps,
-  type ActiveContainerBaseProps,
-  type ActiveContentBaseProps,
+  ActiveActionBaseProps,
+  ActiveContainerBaseProps,
+  ActiveContentBaseProps,
 } from '../../utils/base-types'
 import { staticComponent } from '../../utils/static-component-builder'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -14,12 +14,12 @@ import { Button } from '../Button/Button'
 export interface PopoverProps
   extends ActiveContainerBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface PopoverActionProps
   extends ActiveActionBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'button'> {
+    React.ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
@@ -27,18 +27,18 @@ export interface PopoverActionProps
 export interface PopoverBodyProps
   extends ActiveContentBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface PopoverContentProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }
 
 export interface PopoverHeadingProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface Popover {
   (props: PopoverProps): React.ReactElement

--- a/src/components/Provider/Provider.tsx
+++ b/src/components/Provider/Provider.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
-import { type ReactElement, createContext, useContext, useMemo } from 'react'
+import React, { createContext, useContext, useMemo } from 'react'
 
-import { type Theme } from '../../theme/theme'
+import { Theme } from '../../theme/theme'
 import { themeDefaults } from '../../theme/theme-defaults'
 import { initializeUtilityClassesTheme } from '../../utils/utility-classes'
 
@@ -104,7 +104,7 @@ const ComponentryCtx = createContext<null | { components: Components; theme: The
 )
 
 interface ComponentryProviderProps {
-  children: ReactElement
+  children: React.ReactElement
   /** Component default props */
   components?: Components
   /** Application theme values */

--- a/src/components/Table/Table.ts
+++ b/src/components/Table/Table.ts
@@ -1,12 +1,13 @@
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithoutRef } from 'react'
 import { staticComponent } from '../../utils/static-component-builder'
+import { UtilityProps } from '../../utils/utility-classes'
 
-export interface TableProps extends ComponentBaseProps<'div'> {}
-export interface TableBodyProps extends ComponentBaseProps<'div'> {}
-export interface TableCellProps extends ComponentBaseProps<'div'> {}
-export interface TableHeadProps extends ComponentBaseProps<'div'> {}
-export interface TableHeaderProps extends ComponentBaseProps<'div'> {}
-export interface TableRowProps extends ComponentBaseProps<'div'> {}
+export interface TableProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface TableBodyProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface TableCellProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface TableHeadProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface TableHeaderProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface TableRowProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
 
 export interface Table {
   (props: TableProps): React.ReactElement

--- a/src/components/Table/Table.ts
+++ b/src/components/Table/Table.ts
@@ -1,13 +1,23 @@
-import { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { staticComponent } from '../../utils/static-component-builder'
 import { UtilityProps } from '../../utils/utility-classes'
 
-export interface TableProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-export interface TableBodyProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-export interface TableCellProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-export interface TableHeadProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-export interface TableHeaderProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
-export interface TableRowProps extends UtilityProps, ComponentPropsWithoutRef<'div'> {}
+export interface TableProps extends UtilityProps, React.ComponentPropsWithoutRef<'div'> {}
+export interface TableBodyProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
+export interface TableCellProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
+export interface TableHeadProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
+export interface TableHeaderProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
+export interface TableRowProps
+  extends UtilityProps,
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface Table {
   (props: TableProps): React.ReactElement

--- a/src/components/Tabs/Tabs.ts
+++ b/src/components/Tabs/Tabs.ts
@@ -1,3 +1,4 @@
+import { type ComponentPropsWithoutRef } from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
@@ -5,32 +6,41 @@ import {
   type ActiveActionBaseProps,
   type ActiveContainerBaseProps,
   type ActiveContentBaseProps,
-  type ComponentBaseProps,
 } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Link } from '../Link/Link'
 import { useThemeProps } from '../Provider/Provider'
 
-export interface TabsProps extends ActiveContainerBaseProps, ComponentBaseProps<'div'> {}
+export interface TabsProps
+  extends ActiveContainerBaseProps,
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
-export interface TabsActionsContainerProps extends ComponentBaseProps<'div'> {
+export interface TabsActionsContainerProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'div'> {
   /** Pill style tabs */
   pills?: boolean // TODO: This should be a variant on Tabs
 }
 
 export interface TabsActionProps
   extends ActiveActionBaseProps,
-    ComponentBaseProps<'button'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
 
-export interface TabsContentContainerProps extends ComponentBaseProps<'div'> {}
+export interface TabsContentContainerProps
+  extends UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface TabsContentProps
   extends ActiveContentBaseProps,
-    ComponentBaseProps<'div'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }

--- a/src/components/Tabs/Tabs.ts
+++ b/src/components/Tabs/Tabs.ts
@@ -1,11 +1,11 @@
-import { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  type ActiveActionBaseProps,
-  type ActiveContainerBaseProps,
-  type ActiveContentBaseProps,
+  ActiveActionBaseProps,
+  ActiveContainerBaseProps,
+  ActiveContentBaseProps,
 } from '../../utils/base-types'
 import { element } from '../../utils/element-creator'
 import { staticComponent } from '../../utils/static-component-builder'
@@ -16,11 +16,11 @@ import { useThemeProps } from '../Provider/Provider'
 export interface TabsProps
   extends ActiveContainerBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface TabsActionsContainerProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Pill style tabs */
   pills?: boolean // TODO: This should be a variant on Tabs
 }
@@ -28,19 +28,19 @@ export interface TabsActionsContainerProps
 export interface TabsActionProps
   extends ActiveActionBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'button'> {
+    React.ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
 
 export interface TabsContentContainerProps
   extends UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface TabsContentProps
   extends ActiveContentBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -1,7 +1,7 @@
-import { type ComponentType, forwardRef } from 'react'
-import { type ComponentBaseProps } from '../../utils/base-types'
+import { type ComponentPropsWithRef, type ComponentType, forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { type MergePropTypes } from '../../utils/types'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
 // --------------------------------------------------------
@@ -66,12 +66,13 @@ export interface TextPropsDefaults {
   truncate?: boolean
 }
 
-export type TextProps = MergePropTypes<TextPropsDefaults, TextPropsOverrides> &
-  ComponentBaseProps<'div'>
+export type TextProps = Resolve<MergeTypes<TextPropsDefaults, TextPropsOverrides>> &
+  UtilityProps &
+  ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Text {
-  (props: TextProps & { ref?: React.ForwardedRef<unknown> }): React.ReactElement | null
+  (props: TextProps): React.ReactElement | null
   displayName?: string
 }
 

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, type ComponentType, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -18,7 +18,7 @@ import { useThemeProps } from '../Provider/Provider'
  * ```
  */
 export type TextElementsMap = {
-  [Variant: string]: keyof JSX.IntrinsicElements | ComponentType<unknown>
+  [Variant: string]: keyof JSX.IntrinsicElements | React.ComponentType<unknown>
 }
 /**
  * Internal map used for final rendering
@@ -68,7 +68,7 @@ export interface TextPropsDefaults {
 
 export type TextProps = Resolve<MergeTypes<TextPropsDefaults, TextPropsOverrides>> &
   UtilityProps &
-  ComponentPropsWithRef<'div'>
+  React.ComponentPropsWithRef<'div'>
 
 // ✨ Nice display type for IntelliSense
 export interface Text {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,11 +1,11 @@
-import React, { type ComponentPropsWithoutRef } from 'react'
+import React from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
 import {
-  type ActiveActionBaseProps,
-  type ActiveContainerBaseProps,
-  type ActiveContentBaseProps,
+  ActiveActionBaseProps,
+  ActiveContainerBaseProps,
+  ActiveContentBaseProps,
 } from '../../utils/base-types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { Link } from '../Link/Link'
@@ -13,12 +13,12 @@ import { Link } from '../Link/Link'
 export interface TooltipProps
   extends ActiveContainerBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {}
+    React.ComponentPropsWithoutRef<'div'> {}
 
 export interface TooltipActionProps
   extends ActiveActionBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'button'> {
+    React.ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
@@ -26,7 +26,7 @@ export interface TooltipActionProps
 export interface TooltipContentProps
   extends ActiveContentBaseProps,
     UtilityProps,
-    ComponentPropsWithoutRef<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-
+import React, { type ComponentPropsWithoutRef } from 'react'
 import { activeActionBuilder } from '../../utils/active-action-component-builder'
 import { activeContainerBuilder } from '../../utils/active-container-component-builder'
 import { activeContentBuilder } from '../../utils/active-content-component-builder'
@@ -7,24 +6,27 @@ import {
   type ActiveActionBaseProps,
   type ActiveContainerBaseProps,
   type ActiveContentBaseProps,
-  type ComponentBaseProps,
 } from '../../utils/base-types'
+import { UtilityProps } from '../../utils/utility-classes'
 import { Link } from '../Link/Link'
 
 export interface TooltipProps
   extends ActiveContainerBaseProps,
-    ComponentBaseProps<'div'> {}
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {}
 
 export interface TooltipActionProps
   extends ActiveActionBaseProps,
-    ComponentBaseProps<'button'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'button'> {
   /** Display variant */
   variant?: 'primary'
 }
 
 export interface TooltipContentProps
   extends ActiveContentBaseProps,
-    ComponentBaseProps<'div'> {
+    UtilityProps,
+    ComponentPropsWithoutRef<'div'> {
   /** Display variant */
   variant?: 'primary'
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,15 +2,8 @@
  * @file Library hooks
  */
 
-import {
-  type RefObject,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react'
-import { type ActiveContext, ActiveCtx } from './utils/active-container-component-builder'
+import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { ActiveContext, ActiveCtx } from './utils/active-container-component-builder'
 
 // --------------------------------------------------------
 // useActive hook
@@ -26,7 +19,7 @@ export const useActive = (): ActiveContext => useContext(ActiveCtx)
  */
 export const useActiveScrollReset = (
   active: string | boolean,
-  ref: RefObject<HTMLElement>,
+  ref: React.RefObject<HTMLElement>,
 ): void => {
   useLayoutEffect(() => {
     if (active && ref.current) {

--- a/src/plugin-postcss/configs.ts
+++ b/src/plugin-postcss/configs.ts
@@ -1,6 +1,6 @@
 import { lilconfigSync } from 'lilconfig'
 
-import { type Theme, createTheme } from '../theme/theme'
+import { Theme, createTheme } from '../theme/theme'
 
 const explorer = lilconfigSync('componentry')
 

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -5,7 +5,7 @@
  * Testing file for types
  */
 
-import clsx, { type ClassValue } from 'clsx'
+import clsx, { ClassValue } from 'clsx'
 import React, { useRef } from 'react'
 import {
   Active,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,12 +1,12 @@
 import { deepMerge } from '../utils/deep-merge'
-import { MergePropTypes } from '../utils/types'
+import { MergeTypes, Resolve } from '../utils/types'
 import { themeDefaults } from './theme-defaults'
 
 /** Module augmentation interface for overriding default theme values */
 export interface ThemeOverrides {}
 
 /** Application theme values */
-export type Theme = MergePropTypes<typeof themeDefaults, ThemeOverrides>
+export type Theme = Resolve<MergeTypes<typeof themeDefaults, ThemeOverrides>>
 
 /**
  * createTheme merges the passed custom theme values with the Componentry default values

--- a/src/utils/active-action-component-builder.tsx
+++ b/src/utils/active-action-component-builder.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
-import { type Components, useThemeProps } from '../components/Provider/Provider'
+import { Components, useThemeProps } from '../components/Provider/Provider'
 import { ActiveCtx } from './active-container-component-builder'
-import { type ARIAControls, computeARIA } from './aria'
-import { type ActiveActionBaseProps } from './base-types'
+import { ARIAControls, computeARIA } from './aria'
+import { ActiveActionBaseProps } from './base-types'
 import { element } from './element-creator'
 
 interface ActiveActionBuilder {

--- a/src/utils/active-container-component-builder.tsx
+++ b/src/utils/active-container-component-builder.tsx
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid'
 import React, { createContext, useCallback, useEffect, useRef, useState } from 'react'
-import { type Components, useThemeProps } from '../components/Provider/Provider'
-import { type ActiveContainerBaseProps } from './base-types'
+import { Components, useThemeProps } from '../components/Provider/Provider'
+import { ActiveContainerBaseProps } from './base-types'
 import { closest } from './dom'
 import { element } from './element-creator'
 

--- a/src/utils/active-content-component-builder.tsx
+++ b/src/utils/active-content-component-builder.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react'
-import { type Components, useThemeProps } from '../components/Provider/Provider'
+import { Components, useThemeProps } from '../components/Provider/Provider'
 import { useVisible } from '../hooks'
 import { ActiveCtx } from './active-container-component-builder'
-import { type ARIAControls, computeARIA } from './aria'
-import { type ActiveContentBaseProps } from './base-types'
+import { ARIAControls, computeARIA } from './aria'
+import { ActiveContentBaseProps } from './base-types'
 import { element } from './element-creator'
 
 interface ActiveContentBuilder {

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -4,7 +4,7 @@
  * mappings
  */
 
-import { type AriaAttributes } from 'react'
+import { AriaAttributes } from 'react'
 
 type StringBoolean = 'true' | 'false'
 

--- a/src/utils/base-types.ts
+++ b/src/utils/base-types.ts
@@ -3,21 +3,7 @@
  * Base types used for component prop type definitions.
  */
 
-import { type ClassValue } from 'clsx'
-import { type ComponentPropsWithoutRef, type ElementType, type ReactNode } from 'react'
-import { type UtilityProps } from './utility-classes'
-
-/**
- * Base props supported by all Componentry components. Includes the utility
- * styles' props and the HTML attributes for the element DOM type.
- */
-export type ComponentBaseProps<Element extends ElementType> = {
-  /** Component element */
-  as?: ElementType
-  /** Component className, can be a string, array, or object */
-  className?: ClassValue
-} & UtilityProps &
-  Omit<ComponentPropsWithoutRef<Element>, 'className'>
+import { type ReactNode } from 'react'
 
 // --------------------------------------------------------
 // Active components
@@ -25,9 +11,6 @@ export type ComponentBaseProps<Element extends ElementType> = {
 export interface ActiveContainerBaseProps {
   /** Container children */
   children?: ReactNode
-
-  /** Component element */
-  as?: ElementType
 
   /** Sets a container content placement direction className */
   direction?: 'top' | 'left' | 'right' | 'bottom'
@@ -59,8 +42,6 @@ export interface ActiveContainerBaseProps {
 }
 
 export interface ActiveActionBaseProps {
-  /** Component element */
-  as?: ElementType
   /** Action/Content pairing id for compound active components */
   activeId?: string
   /** Component children */
@@ -68,8 +49,6 @@ export interface ActiveActionBaseProps {
 }
 
 export interface ActiveContentBaseProps {
-  /** Component element */
-  as?: ElementType
   /** Action/Content pairing id for compound active components */
   activeId?: string
   /** Component children */

--- a/src/utils/base-types.ts
+++ b/src/utils/base-types.ts
@@ -3,14 +3,14 @@
  * Base types used for component prop type definitions.
  */
 
-import { type ReactNode } from 'react'
+import React from 'react'
 
 // --------------------------------------------------------
 // Active components
 
 export interface ActiveContainerBaseProps {
   /** Container children */
-  children?: ReactNode
+  children?: React.ReactNode
 
   /** Sets a container content placement direction className */
   direction?: 'top' | 'left' | 'right' | 'bottom'
@@ -45,14 +45,14 @@ export interface ActiveActionBaseProps {
   /** Action/Content pairing id for compound active components */
   activeId?: string
   /** Component children */
-  children?: ReactNode
+  children?: React.ReactNode
 }
 
 export interface ActiveContentBaseProps {
   /** Action/Content pairing id for compound active components */
   activeId?: string
   /** Component children */
-  children?: ReactNode
+  children?: React.ReactNode
   /**
    * Controls when the component content is mounted where:
    * - `'always'` - The content will be mounted when the element is both visible

--- a/src/utils/element-creator.tsx
+++ b/src/utils/element-creator.tsx
@@ -1,21 +1,16 @@
-import clsx, { type ClassValue } from 'clsx'
-import {
-  type CSSProperties,
-  type ElementType,
-  type ReactElement,
-  createElement,
-} from 'react'
-import { type UtilityProps, createUtilityClasses } from './utility-classes'
+import clsx, { ClassValue } from 'clsx'
+import React, { createElement } from 'react'
+import { UtilityProps, createUtilityClasses } from './utility-classes'
 
 /**
  * ElementProps includes the shared props _including internal componentCx prop_
  * for all library components.
  */
 type ElementProps = {
-  as?: ElementType
+  as?: React.ElementType
   className?: ClassValue
   componentCx?: ClassValue
-  style?: CSSProperties
+  style?: React.CSSProperties
   themeCx?: ClassValue
 } & UtilityProps
 
@@ -38,7 +33,7 @@ export function element<Props extends ElementProps>({
   style,
   themeCx,
   ...merged
-}: Props): ReactElement {
+}: Props): React.ReactElement {
   // Shared filter point to convert utility props to utility classes
   const { filteredProps, utilityClasses, utilityStyles } = createUtilityClasses(merged)
 

--- a/src/utils/static-component-builder.tsx
+++ b/src/utils/static-component-builder.tsx
@@ -1,4 +1,4 @@
-import { type ClassValue } from 'clsx'
+import { ClassValue } from 'clsx'
 import React from 'react'
 import { useThemeProps } from '../components/Provider/Provider'
 import { element } from './element-creator'

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,23 +1,25 @@
+/* eslint-disable @typescript-eslint/ban-types */
 /**
  * @file
  * Utilities for working with complex TS types.
  */
 
 /**
- * Utility type used to merge default component prop types with user defined
- * overrides.
+ * Type display utility
+ * @see https://effectivetypescript.com/2022/02/25/gentips-4-display/
+ */
+export type Resolve<T> = T extends Function ? T : { [K in keyof T]: T[K] }
+
+/**
+ * Utility type used to merge two types with user defined overrides.
  * @example
  * ```ts
  * export interface ExampleProps {}
  * interface DefaultExampleProps { radical: boolean }
- * type Props = MergePropTypes<DefaultExampleProps, ExampleProps>
+ * type Props = MergeTypes<DefaultExampleProps, ExampleProps>
  * ```
  */
-export type MergePropTypes<Defaults, Overrides> = {
-  [Prop in keyof Defaults]: Prop extends keyof Overrides
-    ? Overrides[Prop]
-    : Defaults[Prop]
-}
+export type MergeTypes<Base, Overrides> = Omit<Base, keyof Overrides> & Overrides
 
 /**
  * Convenience type for reducing boilerplate documenting component style APIs.

--- a/src/utils/utility-classes.ts
+++ b/src/utils/utility-classes.ts
@@ -8,10 +8,10 @@
  * `declare module 'componentry/types/utils/utility-classes' { }`
  */
 
-import { type CSSProperties } from 'react'
+import { type CSSProperties, type ElementType } from 'react'
 import { type Theme } from '../theme/theme'
 import { themeDefaults } from '../theme/theme-defaults'
-import { type MergePropTypes, type UtilityPropsForTheme } from './types'
+import { type MergeTypes, type Resolve, type UtilityPropsForTheme } from './types'
 
 /** Module augmentation interface for overriding default utility props' types */
 export interface UtilityPropsOverrides {}
@@ -28,6 +28,9 @@ export type MaxWidthBase = 'full' | 'min' | 'max' | 'fit' | 'prose' | 'none'
 
 /** Default utility prop types, customizable with UtilityPropsOverrides */
 export interface UtilityPropsBase {
+  /** Component element */
+  as?: ElementType
+
   // ---LAYOUT
   /** Sets a `display` style */
   display?:
@@ -194,7 +197,7 @@ export interface UtilityPropsBase {
 }
 
 /** Componentry utility props for including utility styles. */
-export type UtilityProps = MergePropTypes<UtilityPropsBase, UtilityPropsOverrides>
+export type UtilityProps = Resolve<MergeTypes<UtilityPropsBase, UtilityPropsOverrides>>
 
 const activeProps = {
   activate: 1,

--- a/src/utils/utility-classes.ts
+++ b/src/utils/utility-classes.ts
@@ -8,10 +8,10 @@
  * `declare module 'componentry/types/utils/utility-classes' { }`
  */
 
-import { type CSSProperties, type ElementType } from 'react'
-import { type Theme } from '../theme/theme'
+import React from 'react'
+import { Theme } from '../theme/theme'
 import { themeDefaults } from '../theme/theme-defaults'
-import { type MergeTypes, type Resolve, type UtilityPropsForTheme } from './types'
+import { MergeTypes, Resolve, UtilityPropsForTheme } from './types'
 
 /** Module augmentation interface for overriding default utility props' types */
 export interface UtilityPropsOverrides {}
@@ -29,7 +29,7 @@ export type MaxWidthBase = 'full' | 'min' | 'max' | 'fit' | 'prose' | 'none'
 /** Default utility prop types, customizable with UtilityPropsOverrides */
 export interface UtilityPropsBase {
   /** Component element */
-  as?: ElementType
+  as?: React.ElementType
 
   // ---LAYOUT
   /** Sets a `display` style */
@@ -255,7 +255,7 @@ export function createUtilityClasses<Props extends { [prop: string]: any }>(
   props: Props,
 ) {
   const classes: string[] = []
-  const styles: CSSProperties = {}
+  const styles: React.CSSProperties = {}
   const filteredProps: { [prop: string]: any } = {}
 
   Object.keys(props).forEach((prop) => {


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Upgrades to component type definitions._

1. It's now possible to add props to components using module augmentation thanks to updates to `MergeTypes`
2. Resolved types in editors for consumers should be more concise thanks to `Resolve`


