### PR TITLE
Update: Icon related Button upgrades

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -1,4 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
+import { Icon } from '../Icon/Icon'
 import { Button } from './Button'
 
 <Meta title='Components/Button' component={Button} />
@@ -95,26 +96,26 @@ Pass `fullWidth` to make a button fill its parent container:
 
 <div className='flex flex-col items-center gap-4'>
   <div className='flex gap-4'>
-    <Button variant='filled' startIcon='code' size='small'>
+    <Button variant='filled' startIcon={<Icon id='code' />} size='small'>
       Button
     </Button>
-    <Button variant='filled' endIcon='code' size='small'>
-      Button
-    </Button>
-  </div>
-  <div className='flex gap-4'>
-    <Button variant='filled' startIcon='code'>
-      Button
-    </Button>
-    <Button variant='filled' endIcon='code'>
+    <Button variant='filled' endIcon={<Icon id='code' />} size='small'>
       Button
     </Button>
   </div>
   <div className='flex gap-4'>
-    <Button variant='filled' startIcon='code' size='large'>
+    <Button variant='filled' startIcon={<Icon id='code' />}>
       Button
     </Button>
-    <Button variant='filled' endIcon='code' size='large'>
+    <Button variant='filled' endIcon={<Icon id='code' />}>
+      Button
+    </Button>
+  </div>
+  <div className='flex gap-4'>
+    <Button variant='filled' startIcon={<Icon id='code' />} size='large'>
+      Button
+    </Button>
+    <Button variant='filled' endIcon={<Icon id='code' />} size='large'>
       Button
     </Button>
   </div>

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -88,13 +88,13 @@ export const buttonStyles: ButtonStyles = {
   },
 
   // ICONS
-  '.C9Y-Button-Icon': {
+  '.C9Y-Button-icon': {
     fontSize: '1rem',
   },
-  '.C9Y-Button-Icon-smallSize': {
+  '.C9Y-Button-smallSizeIcon': {
     fontSize: '0.75rem',
   },
-  '.C9Y-Button-Icon-largeSize': {
+  '.C9Y-Button-largeSizeIcon': {
     fontSize: '1.25rem',
   },
 }
@@ -104,8 +104,7 @@ export interface ButtonStyles {
   '.C9Y-Button-base': StylesDefinition
   /** Class applied to disabled buttons' wrapper element */
   '.C9Y-Button-DisabledWrapper': StylesDefinition
-  /** Base class applied to all Button Icons */
-  '.C9Y-Button-Icon': StylesDefinition
+
   /** Variant class applied when `variant="filled"` */
   '.C9Y-Button-filled': {
     '&:hover, &.C9Y-hover': StylesDefinition
@@ -118,12 +117,16 @@ export interface ButtonStyles {
     '&:active, &.C9Y-active': StylesDefinition
     '&:disabled, &.C9Y-disabled': StylesDefinition
   } & StylesDefinition
+
   /** Sizing class applied when `size="small"` */
   '.C9Y-Button-smallSize': StylesDefinition
   /** Sizing class applied when `size="large"` */
   '.C9Y-Button-largeSize': StylesDefinition
+
+  /** Base class applied to all Button Icons */
+  '.C9Y-Button-icon': StylesDefinition
   /** Sizing class applied to Button Icons when `size="small"` */
-  '.C9Y-Button-Icon-smallSize': StylesDefinition
+  '.C9Y-Button-smallSizeIcon': StylesDefinition
   /** Sizing class applied Button Icons when `size="large"` */
-  '.C9Y-Button-Icon-largeSize': StylesDefinition
+  '.C9Y-Button-largeSizeIcon': StylesDefinition
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,7 +3,6 @@ import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
-import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
 
 // Module augmentation interface for overriding component props' types
@@ -16,7 +15,7 @@ export interface ButtonPropsDefaults {
   /** Disables the element, preventing mouse and keyboard events */
   disabled?: boolean
   /** Icon positioned after button content */
-  endIcon?: string | JSX.Element
+  endIcon?: React.ReactElement
   /** Toggles full width element layout */
   fullWidth?: boolean
   /** HTML element href */
@@ -24,7 +23,7 @@ export interface ButtonPropsDefaults {
   /** Sets the display size */
   size?: 'small' | 'large'
   /** Icon positioned before button content */
-  startIcon?: string | JSX.Element
+  startIcon?: React.ReactElement
   /** Display variant */
   variant?: 'filled' | 'outlined'
   /** Indicates whether buttons in a disabled state should be wrapped with a span */
@@ -88,21 +87,21 @@ export const Button: Button = forwardRef((props, ref) => {
       <>
         {startIcon && (
           <span
-            className={clsx('C9Y-Button-Icon', 'C9Y-Button-Icon-startIcon', {
-              [`C9Y-Button-Icon-${size}Size`]: size,
+            className={clsx('C9Y-Button-icon C9Y-Button-startIcon', {
+              [`C9Y-Button-${size}SizeIcon`]: size,
             })}
           >
-            {typeof startIcon === 'string' ? <Icon id={startIcon} /> : startIcon}
+            {startIcon}
           </span>
         )}
         {children}
         {endIcon && (
           <span
-            className={clsx('C9Y-Button-Icon', 'C9Y-Button-Icon-endIcon', {
-              [`C9Y-Button-Icon-${size}Size`]: size,
+            className={clsx('C9Y-Button-icon C9Y-Button-endIcon', {
+              [`C9Y-Button-${size}SizeIcon`]: size,
             })}
           >
-            {typeof endIcon === 'string' ? <Icon id={endIcon} /> : endIcon}
+            {endIcon}
           </span>
         )}
       </>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -69,7 +69,6 @@ export const Button: Button = forwardRef((props, ref) => {
     ...props,
   }
 
-  const iconCx = clsx('C9Y-Button-Icon', { [`C9Y-Button-Icon-${size}Size`]: size })
   const contents = element({
     ref,
     disabled,
@@ -88,13 +87,21 @@ export const Button: Button = forwardRef((props, ref) => {
     children: (
       <>
         {startIcon && (
-          <span className={iconCx}>
+          <span
+            className={clsx('C9Y-Button-Icon', 'C9Y-Button-Icon-startIcon', {
+              [`C9Y-Button-Icon-${size}Size`]: size,
+            })}
+          >
             {typeof startIcon === 'string' ? <Icon id={startIcon} /> : startIcon}
           </span>
         )}
         {children}
         {endIcon && (
-          <span className={iconCx}>
+          <span
+            className={clsx('C9Y-Button-Icon', 'C9Y-Button-Icon-endIcon', {
+              [`C9Y-Button-Icon-${size}Size`]: size,
+            })}
+          >
             {typeof endIcon === 'string' ? <Icon id={endIcon} /> : endIcon}
           </span>
         )}

--- a/src/components/IconButton/IconButton.spec.js
+++ b/src/components/IconButton/IconButton.spec.js
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 
 import { elementTests } from '../../test/element-tests'
+import { Icon } from '../Icon/Icon'
 import { IconButton } from './IconButton'
 
 describe('<IconButton/>', () => {
@@ -8,7 +9,7 @@ describe('<IconButton/>', () => {
   elementTests(IconButton)
 
   it('When no props are passed, then defaults should be rendered', () => {
-    render(<IconButton icon='code' />)
+    render(<IconButton icon={<Icon id='code' />} />)
 
     // By default the button should have type button for a11y
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
@@ -19,13 +20,13 @@ describe('<IconButton/>', () => {
   })
 
   it('When `type` is passed, then it overrides the default', () => {
-    render(<IconButton icon='code' type='submit' />)
+    render(<IconButton icon={<Icon id='code' />} type='submit' />)
 
     expect(screen.getByRole('button')).toHaveAttribute('type', 'submit')
   })
 
   it('When `variant` is passed, then it should be used as base className value', () => {
-    render(<IconButton variant='outlined' icon='code' />)
+    render(<IconButton variant='outlined' icon={<Icon id='code' />} />)
 
     expect(screen.getByRole('button')).toHaveClass(
       'C9Y-IconButton-base C9Y-IconButton-outlined',
@@ -33,7 +34,7 @@ describe('<IconButton/>', () => {
   })
 
   it('When `color` is passed, then the color className should render', () => {
-    render(<IconButton icon='code' color='primary' />)
+    render(<IconButton icon={<Icon id='code' />} color='primary' />)
 
     expect(screen.getByRole('button')).toHaveClass(
       'C9Y-IconButton-base  C9Y-IconButton-filled C9Y-IconButton-primaryColor',
@@ -41,7 +42,7 @@ describe('<IconButton/>', () => {
   })
 
   it('When `size` is passed, then the size className should render', () => {
-    render(<IconButton icon='code' size='small' />)
+    render(<IconButton icon={<Icon id='code' />} size='small' />)
 
     expect(screen.getByRole('button')).toHaveClass(
       'C9Y-IconButton-base C9Y-IconButton-smallSize',
@@ -53,7 +54,7 @@ describe('<IconButton/>', () => {
 // ---------------------------------------------------------------------------
 describe('<IconButton /> Snapshots', () => {
   it('renders defaults correctly', () => {
-    render(<IconButton icon='code' />)
+    render(<IconButton icon={<Icon id='code' />} />)
 
     expect(screen.getByRole('button')).toMatchSnapshot()
   })

--- a/src/components/IconButton/IconButton.stories.mdx
+++ b/src/components/IconButton/IconButton.stories.mdx
@@ -1,4 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
+import { Icon } from '../Icon/Icon'
 import { IconButton } from './IconButton'
 
 <Meta title='Components/IconButton' component={IconButton} />
@@ -25,14 +26,14 @@ Pass a `filled` or `outlined` variant to set a button style.
     ),
   ]}
 >
-  <IconButton variant='filled' icon='code' />
-  <IconButton variant='filled' icon='code' className='C9Y-hover' />
-  <IconButton variant='filled' icon='code' className='C9Y-active' />
-  <IconButton variant='filled' icon='code' disabled />
-  <IconButton variant='outlined' icon='code' />
-  <IconButton variant='outlined' icon='code' className='C9Y-hover' />
-  <IconButton variant='outlined' icon='code' className='C9Y-active' />
-  <IconButton variant='outlined' icon='code' disabled />
+  <IconButton variant='filled' icon={<Icon id='code' />} />
+  <IconButton variant='filled' icon={<Icon id='code' />} className='C9Y-hover' />
+  <IconButton variant='filled' icon={<Icon id='code' />} className='C9Y-active' />
+  <IconButton variant='filled' icon={<Icon id='code' />} disabled />
+  <IconButton variant='outlined' icon={<Icon id='code' />} />
+  <IconButton variant='outlined' icon={<Icon id='code' />} className='C9Y-hover' />
+  <IconButton variant='outlined' icon={<Icon id='code' />} className='C9Y-active' />
+  <IconButton variant='outlined' icon={<Icon id='code' />} disabled />
 </Story>
 
 ## Sizes
@@ -41,14 +42,14 @@ Pass a `size` to set a button size:
 
 <div className='flex flex-col gap-4 justify-center'>
   <div className='flex flex-row items-center gap-4'>
-    <IconButton variant='filled' icon='code' size='small' />
-    <IconButton variant='filled' icon='code' />
-    <IconButton variant='filled' icon='code' size='large' />
+    <IconButton variant='filled' icon={<Icon id='code' />} size='small' />
+    <IconButton variant='filled' icon={<Icon id='code' />} />
+    <IconButton variant='filled' icon={<Icon id='code' />} size='large' />
   </div>
   <div className='flex flex-row items-center gap-4'>
-    <IconButton variant='outlined' icon='code' size='small' />
-    <IconButton variant='outlined' icon='code' />
-    <IconButton variant='outlined' icon='code' size='large' />
+    <IconButton variant='outlined' icon={<Icon id='code' />} size='small' />
+    <IconButton variant='outlined' icon={<Icon id='code' />} />
+    <IconButton variant='outlined' icon={<Icon id='code' />} size='large' />
   </div>
 </div>
 
@@ -62,7 +63,7 @@ Pass a `size` to set a button size:
   no effect on `pointer-events: none` button element
 
 <div className='flex items-center gap-4'>
-  <IconButton icon='code' disabled />
+  <IconButton icon={<Icon id='code' />} disabled />
 </div>
 
 ## IconButtons with hrefs
@@ -70,8 +71,8 @@ Pass a `size` to set a button size:
 IconButtons with an `href` will be rendered as anchors:
 
 <div className='flex flex-col items-center gap-4'>
-  <IconButton icon='code' href='#test' />
-  <IconButton disabled icon='code' href='#test' />
+  <IconButton icon={<Icon id='code' />} href='#test' />
+  <IconButton disabled icon={<Icon id='code' />} href='#test' />
 </div>
 
 <ArgsTable of={IconButton} />

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
 import { MergeTypes, Resolve } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
-import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
 
 // Module augmentation interface for overriding component props' types
@@ -14,7 +13,7 @@ export interface IconButtonPropsDefaults {
   /** Disables the element, preventing mouse and keyboard events */
   disabled?: boolean
   /** Button content */
-  icon: string | JSX.Element
+  icon: React.ReactElement
   /** Toggles full width element layout */
   fullWidth?: boolean
   /** HTML element href */
@@ -24,7 +23,7 @@ export interface IconButtonPropsDefaults {
   /** Indicates whether buttons in a disabled state should be wrapped with a span */
   wrapWhenDisabled?: boolean
   /** Display variant */
-  variant?: 'transparent' | 'outlined'
+  variant?: 'filled' | 'outlined'
 }
 
 export type IconButtonProps = Resolve<
@@ -67,7 +66,8 @@ export const IconButton: IconButton = forwardRef((props, ref) => {
     disabled,
     // If an href is passed, this instance should render an anchor tag
     as: merged.href ? 'a' : 'button',
-    type: merged.href ? undefined : 'button',
+    // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
+    type: merged.href || merged.to ? undefined : 'button',
     componentCx: [
       `C9Y-IconButton-base C9Y-IconButton-${variant}`,
       {
@@ -75,7 +75,7 @@ export const IconButton: IconButton = forwardRef((props, ref) => {
         [`C9Y-IconButton-${size}Size`]: size,
       },
     ],
-    children: typeof icon === 'string' ? <Icon id={icon} /> : icon,
+    children: icon,
     ...merged,
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   type IconElementsMap,
   type IconProps,
 } from './components/Icon/Icon'
+export { IconButton, type IconButtonProps } from './components/IconButton/IconButton'
 export { Input } from './components/Input/Input'
 export { Link, type LinkProps } from './components/Link/Link'
 export { Modal } from './components/Modal/Modal'

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -54,10 +54,10 @@ const testBadge = <Badge variant='filled'>77</Badge>
 const testBlock = <Block>test block</Block>
 const testButton = (
   <>
-    <Button variant='filled' size='small' startIcon='code' active>
+    <Button variant='filled' size='small' startIcon={<Icon id='code' />} active>
       Click
     </Button>
-    <Button variant='filled' size='small' startIcon={<Icon id='code' />} active>
+    <Button variant='filled' size='small' endIcon={<Icon id='code' />} active>
       Click
     </Button>
   </>


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

Includes a number of API upgrades for working with Buttons and Icons

### Notes

- Props startIcon, endIcon, and icon all require a ReactElement now
- Button icons have classes `C9Y-Button-icon`, `C9Y-Button-startIcon`, and `C9Y-Button-smallSizeIcon`
- ButtonIcon type checks for `to`

<!-- Thank you for contributing, you are AWESOME 🥳 -->
