### PR TITLE
Fix: Include require import for browsers for Jest 28

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ".": {
       "browser": {
         "import": "./dist/browser/index.js",
-        "require": "./dist/browser/index.js"
+        "require": "./dist/commonjs/index.js"
       },
       "node": {
         "import": "./dist/browser/index.js",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
     "./postcss": "./dist/commonjs/plugin-postcss/index.js",
     "./api-docs": "./dist/api-docs.json",
     ".": {
-      "browser": "./dist/browser/index.js",
+      "browser": {
+        "import": "./dist/browser/index.js",
+        "require": "./dist/browser/index.js"
+      },
       "node": {
-        "module": "./dist/browser/index.js",
+        "import": "./dist/browser/index.js",
         "require": "./dist/commonjs/index.js"
       },
       "default": "./dist/browser/index.js"


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Fixes an issue where the library fails in Jest v28_

### Notes

- See: https://jestjs.io/docs/upgrading-to-jest28#packagejson-exports
- See: https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#conditional-exports
<!-- Thank you for contributing, you are AWESOME 🥳 -->
