### PR TITLE
Remove wrapWhenDisabled prop from action elements

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -69,9 +69,6 @@ Pass `fullWidth` to make a button fill its parent container:
 - Controlled by `disabled` prop
 - Adds `disabled` attribute to element and `.C9Y-Disabled` class
 - Adds `pointer-events: none` to prevent user actions
-- Prop `wrapWhenDisabled` controls wrapping disabled buttons with a span to support
-  accessing a ref (eg for tooltip) and to support setting `cursor: not-allowed` which has
-  no effect on `pointer-events: none` button element
 
 <div className='flex flex-col items-center gap-4'>
   <div className='flex flex-row items-center gap-4'>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -26,8 +26,6 @@ export interface ButtonPropsDefaults {
   startIcon?: React.ReactElement
   /** Display variant */
   variant?: 'filled' | 'outlined'
-  /** Indicates whether buttons in a disabled state should be wrapped with a span */
-  wrapWhenDisabled?: boolean
 }
 
 export type ButtonProps = Resolve<MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides>> &
@@ -61,14 +59,13 @@ export const Button: Button = forwardRef((props, ref) => {
     color,
     fullWidth,
     size,
-    wrapWhenDisabled = true,
     ...merged
   } = {
     ...useThemeProps('Button'),
     ...props,
   }
 
-  const contents = element({
+  return element({
     ref,
     disabled,
     // If an href is passed, this instance should render an anchor tag
@@ -108,13 +105,5 @@ export const Button: Button = forwardRef((props, ref) => {
     ),
     ...merged,
   })
-
-  return disabled && wrapWhenDisabled ? (
-    <span className={clsx('C9Y-Button-DisabledWrapper', { 'w-full': fullWidth })}>
-      {contents}
-    </span>
-  ) : (
-    contents
-  )
 })
 Button.displayName = 'Button'

--- a/src/components/IconButton/IconButton.stories.mdx
+++ b/src/components/IconButton/IconButton.stories.mdx
@@ -58,9 +58,6 @@ Pass a `size` to set a button size:
 - Controlled by `disabled` prop
 - Adds `disabled` attribute to element and `.C9Y-Disabled` class
 - Adds `pointer-events: none` to prevent user actions
-- Prop `wrapWhenDisabled` controls wrapping disabled buttons with a span to support
-  accessing a ref (eg for tooltip) and to support setting `cursor: not-allowed` which has
-  no effect on `pointer-events: none` button element
 
 <div className='flex items-center gap-4'>
   <IconButton icon={<Icon id='code' />} disabled />

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -20,8 +20,6 @@ export interface IconButtonPropsDefaults {
   href?: string
   /** Sets the display size */
   size?: 'small' | 'large'
-  /** Indicates whether buttons in a disabled state should be wrapped with a span */
-  wrapWhenDisabled?: boolean
   /** Display variant */
   variant?: 'filled' | 'outlined'
 }
@@ -54,14 +52,13 @@ export const IconButton: IconButton = forwardRef((props, ref) => {
     disabled,
     icon,
     size,
-    wrapWhenDisabled = true,
     ...merged
   } = {
     ...useThemeProps('IconButton'),
     ...props,
   }
 
-  const contents = element({
+  return element({
     ref,
     disabled,
     // If an href is passed, this instance should render an anchor tag
@@ -78,11 +75,5 @@ export const IconButton: IconButton = forwardRef((props, ref) => {
     children: icon,
     ...merged,
   })
-
-  return disabled && wrapWhenDisabled ? (
-    <span className='C9Y-IconButton-DisabledWrapper'>{contents}</span>
-  ) : (
-    contents
-  )
 })
 IconButton.displayName = 'IconButton'

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -14,8 +14,6 @@ export interface LinkPropsDefaults {
   href?: string
   /** Display variant */
   variant?: 'text'
-  /** Indicates whether buttons in a disabled state should be wrapped with a span */
-  wrapWhenDisabled?: boolean
 }
 
 export type LinkProps = Resolve<MergeTypes<LinkPropsDefaults, LinkPropsOverrides>> &
@@ -43,26 +41,20 @@ export const Link: Link = forwardRef((props, ref) => {
   const {
     disabled,
     variant = 'text',
-    wrapWhenDisabled = true,
     ...merged
   } = {
     ...useThemeProps('Link'),
     ...props,
   }
 
-  const contents = element({
+  return element({
     ref,
+    disabled,
     as: merged.href ? 'a' : 'button',
     // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
     type: merged.href || merged.to ? undefined : 'button',
     componentCx: `C9Y-Link-base C9Y-Link-${variant}`,
     ...merged,
   })
-
-  return disabled && wrapWhenDisabled ? (
-    <span className='C9Y-Link-DisabledWrapper'>{contents}</span>
-  ) : (
-    contents
-  )
 })
 Link.displayName = 'Link'

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -43,21 +43,18 @@ exports[`<Tab /> snapshots renders correctly 1`] = `
     >
       Item 3
     </button>
-    <span
-      class="C9Y-Link-DisabledWrapper"
+    <button
+      aria-controls="test-guid-four-content"
+      aria-selected="false"
+      class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction C9Y-disabled C9Y-disabled"
+      data-active-id="four"
+      disabled=""
+      id="test-guid-four-tab"
+      role="tab"
+      type="button"
     >
-      <button
-        aria-controls="test-guid-four-content"
-        aria-selected="false"
-        class="C9Y-Link-base C9Y-Link-text C9Y-TabsAction C9Y-disabled"
-        data-active-id="four"
-        id="test-guid-four-tab"
-        role="tab"
-        type="button"
-      >
-        Disabled
-      </button>
-    </span>
+      Disabled
+    </button>
   </div>
   <div
     class="C9Y-TabsContentContainer"


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Removes the `wrapWhenDisabled` prop and elements from Button, IconButton, and Link_

### Notes

BREAKING CHANGE:

This wrapping element was intended to make the action components "work out of the box" with libraries like MUI/Chakra-UI which require wrapping disabled buttons in a span. Because it's not working as intended it's being removed to keep these elements as simple as possible.

As an alternative consuming libraries can create their own wrapper components around buttons and links to handle auto-support for disabled elements and tooltips.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
