### PR TITLE
Update: Improved polymorphic types that support extending components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,8 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 'off',
     // If a prop is defined it's supposed to be there 😁
     'react/no-unused-prop-types': 'off',
+    // Using `{}` is helpful for component prop types
+    '@typescript-eslint/ban-types': 'off',
     // Componentry uses empty interfaces frequently for module augmentation
     '@typescript-eslint/no-empty-interface': 'off',
   },

--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -9,11 +9,11 @@ export interface BlockPropsOverrides {}
 
 export interface BlockPropsDefaults {}
 
-export type BlockProps<Elem extends React.ElementType = 'div'> = Resolve<
-  MergeTypes<BlockPropsDefaults, BlockPropsOverrides>
-> &
-  UtilityProps &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type BlockPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
+  MergeTypes<BlockPropsDefaults, BlockPropsOverrides> & { as?: Elem }
+
+export type BlockProps<Elem extends React.ElementType = 'div'> = BlockPropsBase<Elem> &
+  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof BlockPropsBase<Elem>>
 
 /**
  * Block provides block layout elements.
@@ -32,11 +32,11 @@ export interface Block {
   displayName?: string
 }
 
-export const Block: Block = forwardRef<HTMLElement, BlockProps>((props, ref) => {
+export const Block = forwardRef<HTMLElement, BlockProps>((props, ref) => {
   return element({
     ref,
     ...useThemeProps('Block'),
     ...props,
   })
-})
+}) as Block
 Block.displayName = 'Block'

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
@@ -28,11 +28,12 @@ export interface ButtonPropsDefaults {
   variant?: 'filled' | 'outlined'
 }
 
-export type ButtonProps<Elem extends React.ElementType = 'button'> = Resolve<
-  MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides>
-> &
-  Omit<UtilityProps, 'color'> &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type ButtonPropsBase<Elem extends React.ElementType = 'button'> = UtilityProps &
+  MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides> & { as?: Elem }
+
+export type ButtonProps<Elem extends React.ElementType = 'button'> =
+  ButtonPropsBase<Elem> &
+    DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof ButtonPropsBase<Elem>>
 
 /**
  * Button provides action elements styled as buttons.
@@ -51,7 +52,7 @@ export interface Button {
   displayName?: string
 }
 
-export const Button: Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => {
+export const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => {
   const {
     variant = 'filled',
     children,
@@ -107,5 +108,5 @@ export const Button: Button = forwardRef<HTMLElement, ButtonProps>((props, ref) 
     ),
     ...merged,
   })
-})
+}) as Button
 Button.displayName = 'Button'

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -18,11 +18,11 @@ export interface FlexPropsDefaults {
   wrap?: 'wrap' | 'nowrap' | 'wrap-reverse'
 }
 
-export type FlexProps<Elem extends React.ElementType = 'div'> = Resolve<
-  MergeTypes<FlexPropsDefaults, FlexPropsOverrides>
-> &
-  UtilityProps &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type FlexPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
+  MergeTypes<FlexPropsDefaults, FlexPropsOverrides> & { as?: Elem }
+
+export type FlexProps<Elem extends React.ElementType = 'div'> = FlexPropsBase<Elem> &
+  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof FlexPropsBase<Elem>>
 
 /**
  * Flex provides flexbox layout elements.
@@ -41,7 +41,7 @@ export interface Flex {
   displayName?: string
 }
 
-export const Flex: Flex = forwardRef<HTMLElement, FlexProps>((props, ref) => {
+export const Flex = forwardRef<HTMLElement, FlexProps>((props, ref) => {
   const { align, direction, justify, wrap, ...rest } = {
     ...useThemeProps('Flex'),
     ...props,
@@ -56,5 +56,5 @@ export const Flex: Flex = forwardRef<HTMLElement, FlexProps>((props, ref) => {
     justifyContent: justify,
     ...rest,
   })
-})
+}) as Flex
 Flex.displayName = 'Flex'

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -14,11 +14,11 @@ export interface GridPropsDefaults {
   justify?: 'start' | 'end' | 'center' | 'stretch'
 }
 
-export type GridProps<Elem extends React.ElementType = 'div'> = Resolve<
-  MergeTypes<GridPropsDefaults, GridPropsOverrides>
-> &
-  UtilityProps &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type GridPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
+  MergeTypes<GridPropsDefaults, GridPropsOverrides> & { as?: Elem }
+
+export type GridProps<Elem extends React.ElementType = 'div'> = GridPropsBase<Elem> &
+  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof GridPropsBase<Elem>>
 
 /**
  * Grid provides CSS grid layout elements
@@ -37,7 +37,7 @@ export interface Grid {
   displayName?: string
 }
 
-export const Grid: Grid = forwardRef<HTMLElement, GridProps>((props, ref) => {
+export const Grid = forwardRef<HTMLElement, GridProps>((props, ref) => {
   const { align, justify, ...rest } = {
     ...useThemeProps('Grid'),
     ...props,
@@ -50,5 +50,5 @@ export const Grid: Grid = forwardRef<HTMLElement, GridProps>((props, ref) => {
     justifyItems: justify,
     ...rest,
   })
-})
+}) as Grid
 Grid.displayName = 'Grid'

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -47,11 +47,11 @@ export interface IconPropsDefaults {
   variant?: 'font'
 }
 
-export type IconProps<Elem extends React.ElementType = 'svg'> = Resolve<
-  MergeTypes<IconPropsDefaults, IconPropsOverrides>
-> &
-  UtilityProps &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type IconPropsBase<Elem extends React.ElementType = 'svg'> = UtilityProps &
+  MergeTypes<IconPropsDefaults, IconPropsOverrides> & { as?: Elem }
+
+export type IconProps<Elem extends React.ElementType = 'svg'> = IconPropsBase<Elem> &
+  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof IconPropsBase<Elem>>
 
 /**
  * Icon provides consistently themed iconography elements.
@@ -68,7 +68,7 @@ export interface Icon {
   displayName?: string
 }
 
-export const Icon: Icon = forwardRef<HTMLElement, IconProps>((props, ref) => {
+export const Icon = forwardRef<HTMLElement, IconProps>((props, ref) => {
   const {
     externalURI = '',
     id,
@@ -87,5 +87,5 @@ export const Icon: Icon = forwardRef<HTMLElement, IconProps>((props, ref) => {
     'aria-label': id,
     ...rest,
   })
-})
+}) as Icon
 Icon.displayName = 'Icon'

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
@@ -25,11 +25,13 @@ export interface IconButtonPropsDefaults {
   variant?: 'filled' | 'outlined'
 }
 
-export type IconButtonProps<Elem extends React.ElementType = 'button'> = Resolve<
-  MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides>
-> &
-  Omit<UtilityProps, 'color'> &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type IconButtonPropsBase<Elem extends React.ElementType = 'button'> =
+  UtilityProps &
+    MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides> & { as?: Elem }
+
+export type IconButtonProps<Elem extends React.ElementType = 'button'> =
+  IconButtonPropsBase<Elem> &
+    DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof IconButtonPropsBase<Elem>>
 
 /**
  * IconButton provides action elements using icons.
@@ -46,37 +48,35 @@ export interface IconButton {
   displayName?: string
 }
 
-export const IconButton: IconButton = forwardRef<HTMLElement, IconButtonProps>(
-  (props, ref) => {
-    const {
-      variant = 'filled',
-      color,
-      disabled,
-      icon,
-      size,
-      ...merged
-    } = {
-      ...useThemeProps('IconButton'),
-      ...props,
-    }
+export const IconButton = forwardRef<HTMLElement, IconButtonProps>((props, ref) => {
+  const {
+    variant = 'filled',
+    color,
+    disabled,
+    icon,
+    size,
+    ...merged
+  } = {
+    ...useThemeProps('IconButton'),
+    ...props,
+  }
 
-    return element({
-      ref,
-      disabled,
-      // If an href is passed, this instance should render an anchor tag
-      as: merged.href ? 'a' : 'button',
-      // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
-      type: merged.href || merged.to ? undefined : 'button',
-      componentCx: [
-        `C9Y-IconButton-base C9Y-IconButton-${variant}`,
-        {
-          [`C9Y-IconButton-${color}Color`]: color,
-          [`C9Y-IconButton-${size}Size`]: size,
-        },
-      ],
-      children: typeof icon === 'string' ? <Icon id={icon} /> : icon,
-      ...merged,
-    })
-  },
-)
+  return element({
+    ref,
+    disabled,
+    // If an href is passed, this instance should render an anchor tag
+    as: merged.href ? 'a' : 'button',
+    // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
+    type: merged.href || merged.to ? undefined : 'button',
+    componentCx: [
+      `C9Y-IconButton-base C9Y-IconButton-${variant}`,
+      {
+        [`C9Y-IconButton-${color}Color`]: color,
+        [`C9Y-IconButton-${size}Size`]: size,
+      },
+    ],
+    children: typeof icon === 'string' ? <Icon id={icon} /> : icon,
+    ...merged,
+  })
+}) as IconButton
 IconButton.displayName = 'IconButton'

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -16,11 +16,11 @@ export interface LinkPropsDefaults {
   variant?: 'text'
 }
 
-export type LinkProps<Elem extends React.ElementType = 'a'> = Resolve<
-  MergeTypes<LinkPropsDefaults, LinkPropsOverrides>
-> &
-  UtilityProps &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type LinkPropsBase<Elem extends React.ElementType = 'a'> = UtilityProps &
+  MergeTypes<LinkPropsDefaults, LinkPropsOverrides> & { as?: Elem }
+
+export type LinkProps<Elem extends React.ElementType = 'a'> = LinkPropsBase<Elem> &
+  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof LinkPropsBase<Elem>>
 
 /**
  * Link provides action elements styled as links.
@@ -39,7 +39,7 @@ export interface Link {
   displayName?: string
 }
 
-export const Link: Link = forwardRef<HTMLElement, LinkProps>((props, ref) => {
+export const Link = forwardRef<HTMLElement, LinkProps>((props, ref) => {
   const {
     disabled,
     variant = 'text',
@@ -58,5 +58,5 @@ export const Link: Link = forwardRef<HTMLElement, LinkProps>((props, ref) => {
     componentCx: `C9Y-Link-base C9Y-Link-${variant}`,
     ...merged,
   })
-})
+}) as Link
 Link.displayName = 'Link'

--- a/src/components/Paper/Paper.ts
+++ b/src/components/Paper/Paper.ts
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -12,11 +12,11 @@ export interface PaperPropsDefaults {
   variant?: 'flat'
 }
 
-export type PaperProps<Elem extends React.ElementType = 'div'> = Resolve<
-  MergeTypes<PaperPropsDefaults, PaperPropsOverrides>
-> &
-  UtilityProps &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type PaperPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
+  MergeTypes<PaperPropsDefaults, PaperPropsOverrides> & { as?: Elem }
+
+export type PaperProps<Elem extends React.ElementType = 'div'> = PaperPropsBase<Elem> &
+  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof PaperPropsBase<Elem>>
 
 /**
  * Paper provides containers for custom elements.
@@ -35,7 +35,7 @@ export interface Paper {
   displayName?: string
 }
 
-export const Paper: Paper = forwardRef<HTMLElement, PaperProps>((props, ref) => {
+export const Paper = forwardRef<HTMLElement, PaperProps>((props, ref) => {
   const { variant = 'flat', ...rest } = {
     ...useThemeProps('Paper'),
     ...props,
@@ -46,5 +46,5 @@ export const Paper: Paper = forwardRef<HTMLElement, PaperProps>((props, ref) => 
     componentCx: ['C9Y-Paper-base', `C9Y-Paper-${variant}`],
     ...rest,
   })
-})
+}) as Paper
 Paper.displayName = 'Paper'

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { element } from '../../utils/element-creator'
-import { MergeTypes, Resolve } from '../../utils/types'
+import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -64,11 +64,11 @@ export interface TextPropsDefaults {
   truncate?: boolean
 }
 
-export type TextProps<Elem extends React.ElementType = 'div'> = Resolve<
-  MergeTypes<TextPropsDefaults, TextPropsOverrides>
-> &
-  UtilityProps &
-  React.ComponentPropsWithRef<Elem> & { as?: Elem }
+export type TextPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
+  MergeTypes<TextPropsDefaults, TextPropsOverrides> & { as?: Elem }
+
+export type TextProps<Elem extends React.ElementType = 'div'> = TextPropsBase<Elem> &
+  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof TextPropsBase<Elem>>
 
 /**
  * Text provides consistently themed typography elements.
@@ -87,7 +87,7 @@ export interface Text {
   displayName?: string
 }
 
-export const Text: Text = forwardRef<HTMLDivElement, TextProps>((props, ref) => {
+export const Text = forwardRef<HTMLDivElement, TextProps>((props, ref) => {
   const {
     truncate = false,
     variant = 'body',
@@ -103,5 +103,5 @@ export const Text: Text = forwardRef<HTMLDivElement, TextProps>((props, ref) => 
     componentCx: [`C9Y-Text-base C9Y-Text-${variant}`, { truncate }],
     ...rest,
   })
-})
+}) as Text
 Text.displayName = 'Text'

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -22,6 +22,7 @@ import {
   Link,
   Paper,
   Text,
+  TextProps,
   useTheme,
 } from '..'
 
@@ -58,6 +59,63 @@ const assertComponentAsProp = (
 
 function TestAs({ specialProp }: { specialProp: number }): JSX.Element {
   return <div>Test passing component as {specialProp}</div>
+}
+
+// --------------------------------------------------------
+// EXTENDING COMPONENTS
+
+function ExtendedText(props: TextProps) {
+  return <Text {...props} className='OVERRIDE' />
+}
+
+// Should be able to "extend" a component by wrapping it and using the exported props' type
+function GenericExtendedText<Elem extends React.ElementType = 'div'>(
+  props: TextProps<Elem>,
+) {
+  return <Text {...props} className='OVERRIDE' />
+}
+function ExtendedUsage() {
+  return (
+    <>
+      {/* ✅ Extended component should have types for component props and utility props */}
+      <ExtendedText variant='h1' mt={3}>
+        Huzzah
+      </ExtendedText>
+      {/* @ts-expect-error -- ❌ Invalid props should throw a type error */}
+      <ExtendedText variant='h1' mt={3} oops>
+        Error
+      </ExtendedText>
+      {/* @ts-expect-error -- ❌ Invalid props for the default as should throw a type error */}
+      <ExtendedText htmlFor='id'>Error</ExtendedText>
+      {/* @ts-expect-error -- ❌ Non-generic extends doesn't accept as prop */}
+      <ExtendedText as='label' htmlFor='id'>
+        Huzzah
+      </ExtendedText>
+      {/* @ts-expect-error -- ❌ Invalid props should throw a type error when as has been overridden */}
+      <ExtendedText as='label' htmlFor='id' oops>
+        Huzzah
+      </ExtendedText>
+
+      {/* ✅ Extended component should have types for component props and utility props */}
+      <GenericExtendedText variant='h1' mt={3}>
+        Huzzah
+      </GenericExtendedText>
+      {/* @ts-expect-error -- ❌ Invalid props should throw a type error */}
+      <GenericExtendedText variant='h1' mt={3} oops>
+        Error
+      </GenericExtendedText>
+      {/* @ts-expect-error -- ❌ Invalid props for the default as should throw a type error */}
+      <GenericExtendedText htmlFor='id'>Error</GenericExtendedText>
+      {/* ✅ Extended component as should determine supported props */}
+      <GenericExtendedText as='label' htmlFor='id'>
+        Huzzah
+      </GenericExtendedText>
+      {/* @ts-expect-error -- ❌ Invalid props should throw a type error when as has been overridden */}
+      <GenericExtendedText as='label' htmlFor='id' oops>
+        Huzzah
+      </GenericExtendedText>
+    </>
+  )
 }
 
 // --------------------------------------------------------

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -46,3 +46,9 @@ export type StylesDefinition = {
 export type UtilityPropsForTheme<ThemeValue> = {
   [Key in keyof ThemeValue as Key extends 'DEFAULT' ? boolean : Key]: ThemeValue[Key]
 }
+
+/**
+ * Distributive conditional type utility for using Omit with a union of types,
+ * where K will be omitted from every type in the union.
+ */
+export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Improves the new polymorphic types to work when extending components._

### Notes

Examples of this added in the types test file, patterns like this now type check correctly:

```tsx
// Should be able to "extend" a component by wrapping it and using the exported component's props type.
function ExtendedText(props: TextProps) {
  return <Text {...props} className='OVERRIDE' />
}

// Should be able to create a generic extended component that also supports `as` usage
function GenericExtendedText<Elem extends React.ElementType = 'div'>(
  props: TextProps<Elem>,
) {
  return <Text {...props} className='OVERRIDE' />
}
```
