### PR TITLE
Fix: Omit UtilityProp color from Button components

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -28,7 +28,10 @@ export interface ButtonPropsDefaults {
   variant?: 'filled' | 'outlined'
 }
 
-export type ButtonPropsBase<Elem extends React.ElementType = 'button'> = UtilityProps &
+export type ButtonPropsBase<Elem extends React.ElementType = 'button'> = Omit<
+  UtilityProps,
+  'color'
+> &
   MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides> & { as?: Elem }
 
 export type ButtonProps<Elem extends React.ElementType = 'button'> =

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -25,9 +25,11 @@ export interface IconButtonPropsDefaults {
   variant?: 'filled' | 'outlined'
 }
 
-export type IconButtonPropsBase<Elem extends React.ElementType = 'button'> =
-  UtilityProps &
-    MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides> & { as?: Elem }
+export type IconButtonPropsBase<Elem extends React.ElementType = 'button'> = Omit<
+  UtilityProps,
+  'color'
+> &
+  MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides> & { as?: Elem }
 
 export type IconButtonProps<Elem extends React.ElementType = 'button'> =
   IconButtonPropsBase<Elem> &


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Fix a regression for color prop type in Button and IconButton._

### Notes

- Deleted during polymorphic types update
