### PR TITLE
Fix: Widen component type in IconElementsMap

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -8,7 +8,7 @@ import { useThemeProps } from '../Provider/Provider'
 // ICON ELEMENTS MAP
 
 /** Mapping of icon IDs to components rendered by Icon */
-export type IconElementsMap = { [ID: string]: React.ComponentType<unknown> }
+export type IconElementsMap = { [ID: string]: React.ComponentType }
 
 let iconElementsMap: IconElementsMap = {}
 


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Widen component type to resolve type errors from component props._


