### PR TITLE
Update: Remove components' null return type

### DIFF
--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -26,9 +26,7 @@ export type BlockProps<Elem extends React.ElementType = 'div'> = BlockPropsBase<
  * @see [📝 Block](https://componentry.design/docs/components/block)
  */
 export interface Block {
-  <Elem extends React.ElementType = 'div'>(
-    props: BlockProps<Elem>,
-  ): React.ReactElement | null
+  <Elem extends React.ElementType = 'div'>(props: BlockProps<Elem>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -51,7 +51,7 @@ export type ButtonProps<Elem extends React.ElementType = 'button'> =
 export interface Button {
   <Elem extends React.ElementType = 'button'>(
     props: ButtonProps<Elem>,
-  ): React.ReactElement | null
+  ): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -35,9 +35,7 @@ export type FlexProps<Elem extends React.ElementType = 'div'> = FlexPropsBase<El
  * @see [📝 Flex](https://componentry.design/docs/components/flex)
  */
 export interface Flex {
-  <Elem extends React.ElementType = 'div'>(
-    props: FlexProps<Elem>,
-  ): React.ReactElement | null
+  <Elem extends React.ElementType = 'div'>(props: FlexProps<Elem>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -31,9 +31,7 @@ export type GridProps<Elem extends React.ElementType = 'div'> = GridPropsBase<El
  * @see [📝 Grid](https://componentry.design/docs/components/grid)
  */
 export interface Grid {
-  <Elem extends React.ElementType = 'div'>(
-    props: GridProps<Elem>,
-  ): React.ReactElement | null
+  <Elem extends React.ElementType = 'div'>(props: GridProps<Elem>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -62,9 +62,7 @@ export type IconProps<Elem extends React.ElementType = 'svg'> = IconPropsBase<El
  * @see [📝 Icon](https://componentry.design/docs/components/icon)
  */
 export interface Icon {
-  <Elem extends React.ElementType = 'svg'>(
-    props: IconProps<Elem>,
-  ): React.ReactElement | null
+  <Elem extends React.ElementType = 'svg'>(props: IconProps<Elem>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -46,7 +46,7 @@ export type IconButtonProps<Elem extends React.ElementType = 'button'> =
 export interface IconButton {
   <Elem extends React.ElementType = 'button'>(
     props: IconButtonProps<Elem>,
-  ): React.ReactElement | null
+  ): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -33,9 +33,7 @@ export type LinkProps<Elem extends React.ElementType = 'a'> = LinkPropsBase<Elem
  * @see [📝 Link component](https://componentry.design/docs/components/link)
  */
 export interface Link {
-  <Elem extends React.ElementType = 'a'>(
-    props: LinkProps<Elem>,
-  ): React.ReactElement | null
+  <Elem extends React.ElementType = 'a'>(props: LinkProps<Elem>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Paper/Paper.ts
+++ b/src/components/Paper/Paper.ts
@@ -29,9 +29,7 @@ export type PaperProps<Elem extends React.ElementType = 'div'> = PaperPropsBase<
  * @see [📝 Paper](https://componentry.design/docs/components/paper)
  */
 export interface Paper {
-  <Elem extends React.ElementType = 'div'>(
-    props: PaperProps<Elem>,
-  ): React.ReactElement | null
+  <Elem extends React.ElementType = 'div'>(props: PaperProps<Elem>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -81,9 +81,7 @@ export type TextProps<Elem extends React.ElementType = 'div'> = TextPropsBase<El
  * @see [📝 Text docs](https://componentry.design/docs/components/text)
  */
 export interface Text {
-  <Elem extends React.ElementType = 'div'>(
-    props: TextProps<Elem>,
-  ): React.ReactElement | null
+  <Elem extends React.ElementType = 'div'>(props: TextProps<Elem>): React.ReactElement
   displayName?: string
 }
 


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Removes inaccurate return type of `null` from component type definitions._

### Notes

These components always return a ReactElement.

