### PR TITLE
Update: Move textElementMap to props

### DIFF
--- a/src/components/Text/Text.spec.js
+++ b/src/components/Text/Text.spec.js
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react'
 
 import { elementTests } from '../../test/element-tests'
-import { Text, configureTextElementsMap } from './Text'
+import { ComponentryProvider } from '../Provider/Provider'
+import { Text } from './Text'
 
 describe('<Text/>', () => {
   // Basic library element test suite
@@ -22,12 +23,22 @@ describe('<Text /> snapshots', () => {
 // Configuration
 
 describe('Text', () => {
-  it('configureTextElementsMap allows configuring variant render elements', () => {
-    configureTextElementsMap({
-      rad: 'section',
-    })
-
-    render(<Text variant='rad'>Componentry</Text>)
+  it('ComponentryProvider allows configuring variant render elements', () => {
+    render(
+      <ComponentryProvider
+        config={{
+          defaultProps: {
+            Text: {
+              textElementMap: {
+                rad: 'section',
+              },
+            },
+          },
+        }}
+      >
+        <Text variant='rad'>Componentry</Text>
+      </ComponentryProvider>,
+    )
 
     expect(screen.getByText('Componentry')).toContainHTML(
       '<section class="C9Y-Text-base C9Y-Text-rad">Componentry</section>',

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react'
+import { TextElementMap } from '../../theme/theme-defaults'
 import { element } from '../../utils/element-creator'
 import { DistributiveOmit, MergeTypes } from '../../utils/types'
 import { UtilityProps } from '../../utils/utility-classes'
@@ -7,21 +8,8 @@ import { useThemeProps } from '../Provider/Provider'
 // --------------------------------------------------------
 // TEXT ELEMENTS MAP
 
-/**
- * Mapping of Text variants to rendered elements
- * @example
- * ```ts
- * const textElementsMap: TextElementsMap = {
- *   h1: 'h1',
- *   body: 'p',
- * }
- * ```
- */
-export type TextElementsMap = {
-  [Variant: string]: keyof JSX.IntrinsicElements | React.ComponentType<unknown>
-}
 /** Default element map */
-const defaulTextElementMap: TextElementsMap = {
+const defaulTextElementMap: TextElementMap = {
   h1: 'h1',
   h2: 'h2',
   h3: 'h3',
@@ -38,7 +26,7 @@ export interface TextPropsOverrides {}
 
 export interface TextPropsDefaults {
   /** Mapping of Text variants to rendered elements */
-  textElementMap?: TextElementsMap
+  textElementMap?: TextElementMap
   /** Truncates overflowing text with an ellipses */
   truncate?: boolean
   /** Display variant */

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -20,36 +20,14 @@ import { useThemeProps } from '../Provider/Provider'
 export type TextElementsMap = {
   [Variant: string]: keyof JSX.IntrinsicElements | React.ComponentType<unknown>
 }
-/**
- * Internal map used for final rendering
- * @see {@link configureTextElementsMap}
- */
-let textElementMap: TextElementsMap = {
+/** Default element map */
+const defaulTextElementMap: TextElementsMap = {
   h1: 'h1',
   h2: 'h2',
   h3: 'h3',
   body: 'div',
   code: 'code',
   small: 'small',
-}
-
-/**
- * Configuration method for defining the elements to render for each text
- * variant.
- * @remarks
- * Configured elements are merged with the library default values.
- * @example
- * ```ts
- * // Add a title variant that renders an h1, and render a div instead of a p
- * // for body variants.
- * configureTextElementsMap({
- *   title: 'h1',
- *   body: 'div',
- * })
- * ```
- */
-export function configureTextElementsMap(elementsMap: TextElementsMap): void {
-  textElementMap = { ...textElementMap, ...elementsMap }
 }
 
 // --------------------------------------------------------
@@ -59,9 +37,12 @@ export function configureTextElementsMap(elementsMap: TextElementsMap): void {
 export interface TextPropsOverrides {}
 
 export interface TextPropsDefaults {
-  variant?: 'h1' | 'h2' | 'h3' | 'body' | 'code' | 'small'
+  /** Mapping of Text variants to rendered elements */
+  textElementMap?: TextElementsMap
   /** Truncates overflowing text with an ellipses */
   truncate?: boolean
+  /** Display variant */
+  variant?: 'h1' | 'h2' | 'h3' | 'body' | 'code' | 'small'
 }
 
 export type TextPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
@@ -87,6 +68,7 @@ export interface Text {
 
 export const Text = forwardRef<HTMLDivElement, TextProps>((props, ref) => {
   const {
+    textElementMap = defaulTextElementMap,
     truncate = false,
     variant = 'body',
     ...rest

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,12 +29,7 @@ export { Paper, type PaperProps } from './components/Paper/Paper'
 export { Popover } from './components/Popover/Popover'
 export { Table } from './components/Table/Table'
 export { Tabs } from './components/Tabs/Tabs'
-export {
-  Text,
-  configureTextElementsMap,
-  type TextElementsMap,
-  type TextProps,
-} from './components/Text/Text'
+export { Text, type TextElementsMap, type TextProps } from './components/Text/Text'
 export { Tooltip } from './components/Tooltip/Tooltip'
 
 // --- Utilities

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,12 +29,15 @@ export { Paper, type PaperProps } from './components/Paper/Paper'
 export { Popover } from './components/Popover/Popover'
 export { Table } from './components/Table/Table'
 export { Tabs } from './components/Tabs/Tabs'
-export { Text, type TextElementsMap, type TextProps } from './components/Text/Text'
+export { Text, type TextProps } from './components/Text/Text'
 export { Tooltip } from './components/Tooltip/Tooltip'
+
+// --- THEME
+export { type TextElementMap } from './theme/theme-defaults'
+export { type Theme, createTheme } from './theme/theme'
 
 // --- Utilities
 export { useActive, useActiveScrollReset, useNoScroll, useVisible } from './hooks'
-export { type Theme, createTheme } from './theme/theme'
 export { setupOutlineHandlers } from './utils/dom'
 export {
   createUtilityClasses,

--- a/src/plugin-babel/parse-attributes.ts
+++ b/src/plugin-babel/parse-attributes.ts
@@ -97,8 +97,9 @@ const paperPropsLookup: {
 const textPropsLookup: {
   [key in keyof TextPropsDefaults]-?: 1
 } = {
-  variant: 1,
+  textElementMap: 1,
   truncate: 1,
+  variant: 1,
 }
 
 const componentPropsLookup: { [component: string]: PropLookup } = {

--- a/src/theme/theme-defaults.ts
+++ b/src/theme/theme-defaults.ts
@@ -159,6 +159,9 @@ export const themeDefaults = {
   },
 
   // --- TYPOGRAPHY
+  // remarks: including the text element map in the theme can make it easy to
+  // define the value in a place that is importable by Babel for pre-compiling
+  textElementMap: undefined as undefined | TextElementMap,
   fontFamily: {
     body: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
     mono: "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
@@ -235,3 +238,17 @@ export const themeDefaults = {
     DEFAULT: '0 0.5rem 1rem rgba(73, 80, 87, 0.15)',
   },
 } as const
+
+/**
+ * Mapping of Text variants to rendered elements
+ * @example
+ * ```ts
+ * const textElementsMap: TextElementsMap = {
+ *   h1: 'h1',
+ *   body: 'p',
+ * }
+ * ```
+ */
+export interface TextElementMap {
+  [Variant: string]: keyof JSX.IntrinsicElements | React.ComponentType
+}


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Move textElementMap to Text props_

### Notes

- Enables defining text variants in the application config, which allows a single Babel config
