### PR TITLE
New: Babel plugin custom import path and transform stats

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     {
       files: ['src/plugin-babel/**/*', 'src/test/**/*'],
       rules: {
+        'no-console': 'off',
         'import/no-extraneous-dependencies': 'off',
       },
     },

--- a/src/plugin-babel/__fixtures__/checks-import-paths/code.js
+++ b/src/plugin-babel/__fixtures__/checks-import-paths/code.js
@@ -1,0 +1,20 @@
+import { Flex, Text } from 'componentry'
+import { Grid } from './custom-grid'
+import { Paper } from '@/custom/componentry_path'
+
+export default function Test() {
+  // Test that:
+  // 1. Componentry imports (Flex, Text) are compiled
+  // 2. Non-Componentry imports (Grid) are ignored
+  // 3. Custom import paths (Paper) can be configured
+  return (
+    <Flex>
+      <Grid>
+        <Text>Precompiled for speed</Text>
+      </Grid>
+      <Paper>
+        <Text>Precompiled for speed</Text>
+      </Paper>
+    </Flex>
+  )
+}

--- a/src/plugin-babel/__fixtures__/checks-import-paths/output.js
+++ b/src/plugin-babel/__fixtures__/checks-import-paths/output.js
@@ -1,0 +1,29 @@
+import { Flex, Text } from 'componentry'
+import { Grid } from './custom-grid'
+import { Paper } from '@/custom/componentry_path'
+import { jsx as _jsx } from 'react/jsx-runtime'
+import { jsxs as _jsxs } from 'react/jsx-runtime'
+export default function Test() {
+  // Test that:
+  // 1. Componentry imports (Flex, Text) are compiled
+  // 2. Non-Componentry imports (Grid) are ignored
+  // 3. Custom import paths (Paper) can be configured
+  return /*#__PURE__*/ _jsxs('div', {
+    className: 'flex',
+    children: [
+      /*#__PURE__*/ _jsx(Grid, {
+        children: /*#__PURE__*/ _jsx('div', {
+          className: 'C9Y-Text-base C9Y-Text-body',
+          children: 'Precompiled for speed',
+        }),
+      }),
+      /*#__PURE__*/ _jsx('div', {
+        className: 'C9Y-Paper-base C9Y-Paper-flat',
+        children: /*#__PURE__*/ _jsx('div', {
+          className: 'C9Y-Text-base C9Y-Text-body',
+          children: 'Precompiled for speed',
+        }),
+      }),
+    ],
+  })
+}

--- a/src/plugin-babel/plugin.spec.js
+++ b/src/plugin-babel/plugin.spec.js
@@ -18,9 +18,12 @@ pluginTester({
   // Array of tests format used to allow more descriptive test titles
   tests: [
     {
-      title: 'transforms components',
-      fixture: '__fixtures__/transforms-components/code.js',
-      outputFixture: '__fixtures__/transforms-components/output.js',
+      title: 'checks component import paths',
+      fixture: '__fixtures__/checks-import-paths/code.js',
+      outputFixture: '__fixtures__/checks-import-paths/output.js',
+      pluginOptions: {
+        customImportPath: 'componentry_path',
+      },
     },
     {
       title: 'ignores non-precompile components',

--- a/src/plugin-babel/plugin.ts
+++ b/src/plugin-babel/plugin.ts
@@ -28,7 +28,7 @@ type PluginOptions = {
   debug?: boolean
   dataFlag?: boolean
   /** Additional import path that should qualify components imported as precompilable */
-  customImportPath: string
+  customImportPath?: string
 }
 type ComponentryPlugin = PluginObj<
   PluginPass & {
@@ -83,9 +83,11 @@ export default function componentryPlugin(): ComponentryPlugin {
        */
       ImportDeclaration(path, state) {
         const importPath = path.node.source.value
+        const { customImportPath } = state.opts
+
         if (
           importPath === 'componentry' ||
-          importPath.endsWith(state.opts.customImportPath)
+          (customImportPath && importPath.endsWith(customImportPath))
         ) {
           path.node.specifiers.forEach((specifier) => {
             if (t.isImportSpecifier(specifier)) {


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Update the Babel precompile plugin to include import path checking and successful precompile rate stats_

### Details

- Before precompiling a component the plugin will now check that it was imported from Componentry. This helps guard against components with the same names as Componentry precompile elements that should _NOT_ be transformed.
- Add a `customImportPath` option to the plugin for configuring an additional module that should mark components as compileable.
- Adds a success rate stats logging step when `debug` is enabled.




