### PR TITLE
Add exclude option to Babel plugin

### DIFF
--- a/src/plugin-babel/__fixtures__/exclude_option/code.js
+++ b/src/plugin-babel/__fixtures__/exclude_option/code.js
@@ -1,0 +1,17 @@
+import { Badge, Block, Flex, Grid, Paper, Text } from 'componentry'
+
+export default function Test() {
+  // Test that:
+  // 1. exclude config skips pre-compiling
+  return (
+    <Paper>
+      <Grid>
+        <Flex>
+          <Text>Precompiled for</Text>
+        </Flex>
+        <Block>SPEED</Block>
+        <Badge>Delightful</Badge>
+      </Grid>
+    </Paper>
+  )
+}

--- a/src/plugin-babel/__fixtures__/exclude_option/output.js
+++ b/src/plugin-babel/__fixtures__/exclude_option/output.js
@@ -1,0 +1,28 @@
+import { Badge, Block, Flex, Grid, Paper, Text } from 'componentry'
+import { jsx as _jsx } from 'react/jsx-runtime'
+import { jsxs as _jsxs } from 'react/jsx-runtime'
+export default function Test() {
+  // Test that:
+  // 1. exclude config skips pre-compiling
+  return /*#__PURE__*/ _jsx('div', {
+    className: 'C9Y-Paper-base C9Y-Paper-flat',
+    children: /*#__PURE__*/ _jsxs('div', {
+      className: 'grid',
+      children: [
+        /*#__PURE__*/ _jsx('div', {
+          className: 'flex',
+          children: /*#__PURE__*/ _jsx('div', {
+            className: 'C9Y-Text-base C9Y-Text-body',
+            children: 'Precompiled for',
+          }),
+        }),
+        /*#__PURE__*/ _jsx('div', {
+          children: 'SPEED',
+        }),
+        /*#__PURE__*/ _jsx(Badge, {
+          children: 'Delightful',
+        }),
+      ],
+    }),
+  })
+}

--- a/src/plugin-babel/plugin.spec.js
+++ b/src/plugin-babel/plugin.spec.js
@@ -19,14 +19,6 @@ pluginTester({
   // Array of tests format used to allow more descriptive test titles
   tests: [
     {
-      title: 'checks component import paths',
-      fixture: '__fixtures__/checks-import-paths/code.js',
-      outputFixture: '__fixtures__/checks-import-paths/output.js',
-      pluginOptions: {
-        customImportPath: 'componentry_path',
-      },
-    },
-    {
       title: 'ignores non-precompile components',
       fixture: '__fixtures__/ignores-components/code.js',
       outputFixture: '__fixtures__/ignores-components/output.js',
@@ -66,12 +58,30 @@ pluginTester({
       fixture: '__fixtures__/passthrough-props/code.js',
       outputFixture: '__fixtures__/passthrough-props/output.js',
     },
+    // --------------------------------------------------------
+    // OPTIONS
     {
       title: 'includes a data-precompiled flag when plugin option is used',
       fixture: '__fixtures__/data-precompiled/code.js',
       outputFixture: '__fixtures__/data-precompiled/output.js',
       pluginOptions: {
         dataFlag: true,
+      },
+    },
+    {
+      title: 'checks component import paths',
+      fixture: '__fixtures__/checks-import-paths/code.js',
+      outputFixture: '__fixtures__/checks-import-paths/output.js',
+      pluginOptions: {
+        customImportPath: 'componentry_path',
+      },
+    },
+    {
+      title: 'skips excluded components',
+      fixture: '__fixtures__/exclude_option/code.js',
+      outputFixture: '__fixtures__/exclude_option/output.js',
+      pluginOptions: {
+        exclude: ['Badge'],
       },
     },
   ],

--- a/src/plugin-babel/plugin.ts
+++ b/src/plugin-babel/plugin.ts
@@ -25,8 +25,12 @@ const config = loadConfig()
 
 /** Plugin customization options */
 type PluginOptions = {
+  /** Log additional info for plugin debugging */
   debug?: boolean
+  /** Flag to include data-<component> attributes on precompiled components */
   dataFlag?: boolean
+  /** Components that should be excluded from pre-compilation */
+  exclude?: string[]
   /** Additional import path that should qualify components imported as precompilable */
   customImportPath?: string
 }
@@ -118,6 +122,9 @@ export default function componentryPlugin(): ComponentryPlugin {
           // Bail early if this element isn't one of our precompile targets, or
           // if it wasn't imported from componentry
           if (!(name in components) || !(name in this.componentryImports)) return
+
+          // Bail early if this element has been excluded from pre-compiling
+          if (state.opts.exclude && state.opts.exclude.includes(name)) return
 
           this.stats.elementsVisited += 1
 


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Adds an `exclude` option to the Babel plugin for components that should not be precompiled._

### Notes

- This is useful for consumers that want to create their own version of components

<!-- Thank you for contributing, you are AWESOME 🥳 -->
