### PR TITLE
Update: Simplified type utilities exported

### DIFF
--- a/src/components/Badge/Badge.ts
+++ b/src/components/Badge/Badge.ts
@@ -1,29 +1,28 @@
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 /** Module augmentation interface for overriding component props' types */
 export interface BadgePropsOverrides {}
 
 export interface BadgePropsDefaults {
+  /** Display style */
+  variant?: 'filled'
   /** Theme color for display variant */
   color?: 'primary'
   /** Display size */
   size?: 'small' | 'large'
-  /** Display style */
-  variant?: 'filled'
 }
 
-export type BadgePropsBase<Elem extends React.ElementType = 'div'> = Omit<
-  UtilityProps,
-  'color'
+export type BadgeProps<As extends React.ElementType = 'div'> = Resolve<
+  MergeTypes<BadgePropsDefaults, BadgePropsOverrides> & { as?: As } & Omit<
+      UtilityProps,
+      'color'
+    >
 > &
-  MergeTypes<BadgePropsDefaults, BadgePropsOverrides> & { as?: Elem }
-
-export type BadgeProps<Elem extends React.ElementType = 'div'> = BadgePropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof BadgePropsBase<Elem>>
+  ElementTypeProps<As>
 
 /**
  * Badge provides a short label for describing elements.
@@ -36,7 +35,7 @@ export type BadgeProps<Elem extends React.ElementType = 'div'> = BadgePropsBase<
  * @see [📝 Badge docs](https://componentry.design/docs/components/badge)
  */
 export interface Badge {
-  <Elem extends React.ElementType = 'div'>(props: BadgeProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'div'>(props: BadgeProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Block/Block.ts
+++ b/src/components/Block/Block.ts
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 /** Module augmentation interface for overriding component props' types */
@@ -9,11 +9,10 @@ export interface BlockPropsOverrides {}
 
 export interface BlockPropsDefaults {}
 
-export type BlockPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
-  MergeTypes<BlockPropsDefaults, BlockPropsOverrides> & { as?: Elem }
-
-export type BlockProps<Elem extends React.ElementType = 'div'> = BlockPropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof BlockPropsBase<Elem>>
+export type BlockProps<As extends React.ElementType = 'div'> = Resolve<
+  MergeTypes<BlockPropsDefaults, BlockPropsOverrides> & { as?: As } & UtilityProps
+> &
+  ElementTypeProps<As>
 
 /**
  * Block provides block layout elements.
@@ -26,7 +25,7 @@ export type BlockProps<Elem extends React.ElementType = 'div'> = BlockPropsBase<
  * @see [📝 Block](https://componentry.design/docs/components/block)
  */
 export interface Block {
-  <Elem extends React.ElementType = 'div'>(props: BlockProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'div'>(props: BlockProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx'
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -10,6 +10,8 @@ import { useThemeProps } from '../Provider/Provider'
 export interface ButtonPropsOverrides {}
 
 export interface ButtonPropsDefaults {
+  /** Display style */
+  variant?: 'filled' | 'outlined'
   /** Theme color for display variant */
   color?: 'primary'
   /** Disables the element, preventing mouse and keyboard events */
@@ -24,19 +26,15 @@ export interface ButtonPropsDefaults {
   size?: 'small' | 'large'
   /** Icon positioned before button content */
   startIcon?: string | React.ReactElement
-  /** Display style */
-  variant?: 'filled' | 'outlined'
 }
 
-export type ButtonPropsBase<Elem extends React.ElementType = 'button'> = Omit<
-  UtilityProps,
-  'color'
+export type ButtonProps<As extends React.ElementType = 'button'> = Resolve<
+  MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides> & { as?: As } & Omit<
+      UtilityProps,
+      'color'
+    >
 > &
-  MergeTypes<ButtonPropsDefaults, ButtonPropsOverrides> & { as?: Elem }
-
-export type ButtonProps<Elem extends React.ElementType = 'button'> =
-  ButtonPropsBase<Elem> &
-    DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof ButtonPropsBase<Elem>>
+  ElementTypeProps<As>
 
 /**
  * Button provides action elements styled as buttons.
@@ -49,9 +47,7 @@ export type ButtonProps<Elem extends React.ElementType = 'button'> =
  * @see [📝 Button](https://componentry.design/docs/components/button)
  */
 export interface Button {
-  <Elem extends React.ElementType = 'button'>(
-    props: ButtonProps<Elem>,
-  ): React.ReactElement
+  <As extends React.ElementType = 'button'>(props: ButtonProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Flex/Flex.ts
+++ b/src/components/Flex/Flex.ts
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 /** Module augmentation interface for overriding component props' types */
@@ -18,11 +18,10 @@ export interface FlexPropsDefaults {
   wrap?: 'wrap' | 'nowrap' | 'wrap-reverse'
 }
 
-export type FlexPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
-  MergeTypes<FlexPropsDefaults, FlexPropsOverrides> & { as?: Elem }
-
-export type FlexProps<Elem extends React.ElementType = 'div'> = FlexPropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof FlexPropsBase<Elem>>
+export type FlexProps<As extends React.ElementType = 'div'> = Resolve<
+  MergeTypes<FlexPropsDefaults, FlexPropsOverrides> & { as?: As } & UtilityProps
+> &
+  ElementTypeProps<As>
 
 /**
  * Flex provides flexbox layout elements.
@@ -35,7 +34,7 @@ export type FlexProps<Elem extends React.ElementType = 'div'> = FlexPropsBase<El
  * @see [📝 Flex](https://componentry.design/docs/components/flex)
  */
 export interface Flex {
-  <Elem extends React.ElementType = 'div'>(props: FlexProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'div'>(props: FlexProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Grid/Grid.ts
+++ b/src/components/Grid/Grid.ts
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 /** Module augmentation interface for overriding component props' types */
@@ -14,11 +14,10 @@ export interface GridPropsDefaults {
   justify?: 'start' | 'end' | 'center' | 'stretch'
 }
 
-export type GridPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
-  MergeTypes<GridPropsDefaults, GridPropsOverrides> & { as?: Elem }
-
-export type GridProps<Elem extends React.ElementType = 'div'> = GridPropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof GridPropsBase<Elem>>
+export type GridProps<As extends React.ElementType = 'div'> = Resolve<
+  MergeTypes<GridPropsDefaults, GridPropsOverrides> & { as?: As } & UtilityProps
+> &
+  ElementTypeProps<As>
 
 /**
  * Grid provides CSS grid layout elements
@@ -31,7 +30,7 @@ export type GridProps<Elem extends React.ElementType = 'div'> = GridPropsBase<El
  * @see [📝 Grid](https://componentry.design/docs/components/grid)
  */
 export interface Grid {
-  <Elem extends React.ElementType = 'div'>(props: GridProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'div'>(props: GridProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 // --------------------------------------------------------
@@ -39,19 +39,18 @@ export function configureIconElementsMap(elementsMap: IconElementsMap): void {
 export interface IconPropsOverrides {}
 
 export interface IconPropsDefaults {
+  /** Display variant */
+  variant?: 'font'
   /** External path to symbol sprite  */
   externalURI?: string
   /** ID for the `iconElementsMap` or href attribute for symbol sprites */
   id: string
-  /** Display variant */
-  variant?: 'font'
 }
 
-export type IconPropsBase<Elem extends React.ElementType = 'svg'> = UtilityProps &
-  MergeTypes<IconPropsDefaults, IconPropsOverrides> & { as?: Elem }
-
-export type IconProps<Elem extends React.ElementType = 'svg'> = IconPropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof IconPropsBase<Elem>>
+export type IconProps<As extends React.ElementType = 'svg'> = Resolve<
+  MergeTypes<IconPropsDefaults, IconPropsOverrides> & { as?: As } & UtilityProps
+> &
+  ElementTypeProps<As>
 
 /**
  * Icon provides consistently themed iconography elements.
@@ -62,7 +61,7 @@ export type IconProps<Elem extends React.ElementType = 'svg'> = IconPropsBase<El
  * @see [📝 Icon](https://componentry.design/docs/components/icon)
  */
 export interface Icon {
-  <Elem extends React.ElementType = 'svg'>(props: IconProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'svg'>(props: IconProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -66,6 +66,7 @@ export const IconButton = forwardRef<HTMLElement, IconButtonProps>((props, ref) 
     disabled,
     // If an href is passed, this instance should render an anchor tag
     as: merged.href ? 'a' : 'button',
+    // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
     type: merged.href || merged.to ? undefined : 'button',
     componentClassName: [
       `C9Y-IconButton-base C9Y-IconButton-${variant}`,

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { Icon } from '../Icon/Icon'
 import { useThemeProps } from '../Provider/Provider'
 
@@ -9,6 +9,8 @@ import { useThemeProps } from '../Provider/Provider'
 export interface IconButtonPropsOverrides {}
 
 export interface IconButtonPropsDefaults {
+  /** Display variant */
+  variant?: 'filled' | 'outlined'
   /** Display variant color */
   color?: 'primary'
   /** Disables the element, preventing mouse and keyboard events */
@@ -21,19 +23,15 @@ export interface IconButtonPropsDefaults {
   href?: string
   /** Sets the display size */
   size?: 'small' | 'large'
-  /** Display variant */
-  variant?: 'filled' | 'outlined'
 }
 
-export type IconButtonPropsBase<Elem extends React.ElementType = 'button'> = Omit<
-  UtilityProps,
-  'color'
+export type IconButtonProps<As extends React.ElementType = 'button'> = Resolve<
+  MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides> & { as?: As } & Omit<
+      UtilityProps,
+      'color'
+    >
 > &
-  MergeTypes<IconButtonPropsDefaults, IconButtonPropsOverrides> & { as?: Elem }
-
-export type IconButtonProps<Elem extends React.ElementType = 'button'> =
-  IconButtonPropsBase<Elem> &
-    DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof IconButtonPropsBase<Elem>>
+  ElementTypeProps<As>
 
 /**
  * IconButton provides action elements using icons.
@@ -44,8 +42,8 @@ export type IconButtonProps<Elem extends React.ElementType = 'button'> =
  * @see [📝 IconButton](https://componentry.design/docs/components/iconbutton)
  */
 export interface IconButton {
-  <Elem extends React.ElementType = 'button'>(
-    props: IconButtonProps<Elem>,
+  <As extends React.ElementType = 'button'>(
+    props: IconButtonProps<As>,
   ): React.ReactElement
   displayName?: string
 }
@@ -68,7 +66,6 @@ export const IconButton = forwardRef<HTMLElement, IconButtonProps>((props, ref) 
     disabled,
     // If an href is passed, this instance should render an anchor tag
     as: merged.href ? 'a' : 'button',
-    // @ts-expect-error - Ensure button works for router library usage even though to isn't in props
     type: merged.href || merged.to ? undefined : 'button',
     componentClassName: [
       `C9Y-IconButton-base C9Y-IconButton-${variant}`,

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -1,26 +1,28 @@
 import React, { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 /** Module augmentation interface for overriding component props' types */
 export interface LinkPropsOverrides {}
 
 export interface LinkPropsDefaults {
+  /** Display variant */
+  variant?: 'text'
   /** Disables the element, preventing mouse and keyboard events */
   disabled?: boolean
   /** HTML element href */
   href?: string
-  /** Display variant */
-  variant?: 'text'
 }
 
-export type LinkPropsBase<Elem extends React.ElementType = 'a'> = UtilityProps &
-  MergeTypes<LinkPropsDefaults, LinkPropsOverrides> & { as?: Elem }
-
-export type LinkProps<Elem extends React.ElementType = 'a'> = LinkPropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof LinkPropsBase<Elem>>
+export type LinkProps<As extends React.ElementType = 'a'> = Resolve<
+  MergeTypes<LinkPropsDefaults, LinkPropsOverrides> & { as?: As } & Omit<
+      UtilityProps,
+      'color'
+    >
+> &
+  ElementTypeProps<As>
 
 /**
  * Link provides action elements styled as links.
@@ -33,7 +35,7 @@ export type LinkProps<Elem extends React.ElementType = 'a'> = LinkPropsBase<Elem
  * @see [📝 Link component](https://componentry.design/docs/components/link)
  */
 export interface Link {
-  <Elem extends React.ElementType = 'a'>(props: LinkProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'a'>(props: LinkProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -17,10 +17,7 @@ export interface LinkPropsDefaults {
 }
 
 export type LinkProps<As extends React.ElementType = 'a'> = Resolve<
-  MergeTypes<LinkPropsDefaults, LinkPropsOverrides> & { as?: As } & Omit<
-      UtilityProps,
-      'color'
-    >
+  MergeTypes<LinkPropsDefaults, LinkPropsOverrides> & { as?: As } & UtilityProps
 > &
   ElementTypeProps<As>
 

--- a/src/components/Paper/Paper.ts
+++ b/src/components/Paper/Paper.ts
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 /** Module augmentation interface for overriding component props' types */
@@ -12,11 +12,10 @@ export interface PaperPropsDefaults {
   variant?: 'flat'
 }
 
-export type PaperPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
-  MergeTypes<PaperPropsDefaults, PaperPropsOverrides> & { as?: Elem }
-
-export type PaperProps<Elem extends React.ElementType = 'div'> = PaperPropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof PaperPropsBase<Elem>>
+export type PaperProps<As extends React.ElementType = 'div'> = Resolve<
+  MergeTypes<PaperPropsDefaults, PaperPropsOverrides> & { as?: As } & UtilityProps
+> &
+  ElementTypeProps<As>
 
 /**
  * Paper provides containers for custom elements.
@@ -29,7 +28,7 @@ export type PaperProps<Elem extends React.ElementType = 'div'> = PaperPropsBase<
  * @see [📝 Paper](https://componentry.design/docs/components/paper)
  */
 export interface Paper {
-  <Elem extends React.ElementType = 'div'>(props: PaperProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'div'>(props: PaperProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -1,8 +1,8 @@
 import React, { forwardRef } from 'react'
 import { TextElementMap } from '../../theme/theme-defaults'
 import { createElement } from '../../utils/create-element'
-import { DistributiveOmit, MergeTypes } from '../../utils/types'
-import { UtilityProps } from '../../utils/utility-props'
+import { MergeTypes, Resolve } from '../../utils/types'
+import { ElementTypeProps, UtilityProps } from '../../utils/utility-props'
 import { useThemeProps } from '../Provider/Provider'
 
 // --------------------------------------------------------
@@ -25,19 +25,18 @@ const defaulTextElementMap: TextElementMap = {
 export interface TextPropsOverrides {}
 
 export interface TextPropsDefaults {
-  /** Mapping of Text variants to rendered elements */
-  textElementMap?: TextElementMap
-  /** Truncates overflowing text with an ellipses */
-  truncate?: boolean
   /** Display variant */
   variant?: 'h1' | 'h2' | 'h3' | 'body' | 'code' | 'small'
+  /** Truncates overflowing text with an ellipses */
+  truncate?: boolean
+  /** Mapping of Text variants to rendered elements */
+  textElementMap?: TextElementMap
 }
 
-export type TextPropsBase<Elem extends React.ElementType = 'div'> = UtilityProps &
-  MergeTypes<TextPropsDefaults, TextPropsOverrides> & { as?: Elem }
-
-export type TextProps<Elem extends React.ElementType = 'div'> = TextPropsBase<Elem> &
-  DistributiveOmit<React.ComponentPropsWithRef<Elem>, keyof TextPropsBase<Elem>>
+export type TextProps<As extends React.ElementType = 'div'> = Resolve<
+  MergeTypes<TextPropsDefaults, TextPropsOverrides> & { as?: As } & UtilityProps
+> &
+  ElementTypeProps<As>
 
 /**
  * Text provides consistently themed typography elements.
@@ -50,7 +49,7 @@ export type TextProps<Elem extends React.ElementType = 'div'> = TextPropsBase<El
  * @see [📝 Text docs](https://componentry.design/docs/components/text)
  */
 export interface Text {
-  <Elem extends React.ElementType = 'div'>(props: TextProps<Elem>): React.ReactElement
+  <As extends React.ElementType = 'div'>(props: TextProps<As>): React.ReactElement
   displayName?: string
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,11 +39,13 @@ export { Tooltip } from './components/Tooltip/Tooltip'
 
 // --- Utilities
 export { useActive, useActiveScrollReset, useNoScroll, useVisible } from './hooks'
-export { setupOutlineHandlers } from './utils/dom'
 export { createElement } from './utils/create-element'
+export { setupOutlineHandlers } from './utils/dom'
+export { type MergeTypes } from './utils/types'
 export {
   createUtilityProps,
   initializeUtilityPropsTheme,
+  type ElementTypeProps,
   type UtilityProps,
 } from './utils/utility-props'
 

--- a/src/test/types.tsx
+++ b/src/test/types.tsx
@@ -2,7 +2,6 @@
  * @file TS types testing
  */
 
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { useRef } from 'react'

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,6 @@
 /**
  * @file
- * Utilities for working with complex TS types.
+ * Utility types for working with complex TS types.
  */
 
 /**
@@ -19,27 +19,3 @@ export type Resolve<T> = T extends Function ? T : { [K in keyof T]: T[K] }
  * ```
  */
 export type MergeTypes<Base, Overrides> = Omit<Base, keyof Overrides> & Overrides
-
-/**
- * Utility type converts a theme definition to version that can be used with
- * `keyof` to extract the appropriate props for that theme value (and
- * specifically converting 'DEFAULT' keys to boolean types), eg for flexGrow:
- * ```tsx
- * interface Theme {
- *   flexGrow: { DEFAULT: 1; 0: 0; }
- * }
- * ```
- * The correct utility prop type of `boolean | 0 | undefined` can be extracted as:
- * ```tsx
- * type FlexGrowProp = keyof UtilityPropsForTheme<Theme['flexGrow']>
- * ```
- */
-export type UtilityPropsForTheme<ThemeValue> = {
-  [Key in keyof ThemeValue as Key extends 'DEFAULT' ? boolean : Key]: ThemeValue[Key]
-}
-
-/**
- * Distributive conditional type utility for using Omit with a union of types,
- * where K will be omitted from every type in the union.
- */
-export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never

--- a/src/utils/utility-props.ts
+++ b/src/utils/utility-props.ts
@@ -11,7 +11,7 @@
 import React from 'react'
 import { Theme } from '../theme/theme'
 import { themeDefaults } from '../theme/theme-defaults'
-import { MergeTypes, Resolve, UtilityPropsForTheme } from './types'
+import { MergeTypes, Resolve } from './types'
 
 /** Module augmentation interface for overriding default utility props' types */
 export interface UtilityPropsOverrides {}
@@ -542,3 +542,44 @@ function accessColor(base: any, path: string): string | undefined {
     return undefined
   }, base)
 }
+
+// --------------------------------------------------------
+// UTILITY TYPES
+
+/**
+ * Utility type converts a theme definition to version that can be used with
+ * `keyof` to extract the appropriate props for that theme value.
+ * @remarks
+ * Tailwind's pattern of declaring a base utility class with `'DEFAULT'`
+ * requires this type manipulation to provide the correct set of prop values in
+ * autocomplete, eg for flexGrow:
+ *
+ * ```tsx
+ * interface Theme {
+ *   flexGrow: { DEFAULT: 1; 0: 0; }
+ * }
+ * ```
+ * The correct utility prop type of `boolean | 0 | undefined` can be extracted
+ * as:
+ * ```tsx
+ * type FlexGrowProp = keyof UtilityPropsForTheme<Theme['flexGrow']>
+ * ```
+ */
+type UtilityPropsForTheme<ThemeNamespace> = {
+  [Key in keyof ThemeNamespace as Key extends 'DEFAULT'
+    ? boolean
+    : Key]: ThemeNamespace[Key]
+}
+
+/**
+ * Utility type for component "as" element props.
+ * @remarks
+ * The UtilityProps type has property declarations that shadow DOM element props
+ * like color, or height. This is problematic because extending two types
+ * requires their property declarations all have the same type, if they are
+ * different the resulting type will be never or something similarly unusable.
+ */
+export type ElementTypeProps<Element extends React.ElementType = 'div'> = Omit<
+  React.ComponentPropsWithRef<Element>,
+  keyof UtilityProps
+>


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Summary

_Simplifies the pattern for component prop types and exposes an `ElementTypeProps` utility type for creating custom components._

### Notes

- Replaces the previous pattern for component prop types which required the very complex `DistributiveOmit` utility type as well as multiple layers of type generics in order to get component polymorphism to work.
- The updated pattern provides a simpler single layer generic type to create a component prop type.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
